### PR TITLE
fix: guard reward-address fallback in signData card

### DIFF
--- a/src/components/cards/signDataCard.js
+++ b/src/components/cards/signDataCard.js
@@ -17,10 +17,14 @@ const SignDataCard = ({api, onRawResponse, onResponse, onWaiting}) => {
     }
     // Otherwise, use the reward address as default
     try {
-      const rewardHexAddress = (await api?.getRewardAddresses())[0]
+      const rewardAddresses = await api?.getRewardAddresses()
+      const rewardHexAddress = rewardAddresses?.[0]
+      if (!rewardHexAddress) {
+        throw new Error('No reward address available — enter an address manually')
+      }
       return getBech32AddressFromHex(rewardHexAddress)
     } catch (error) {
-      throw new Error(error)
+      throw error
     }
   }
 


### PR DESCRIPTION
## Problem

The CIP-30 signData card (`src/components/cards/signDataCard.js`) uses the wallet's reward address as a fallback when the user leaves the Address field empty. When `getRewardAddresses()` returns an empty array (e.g. wallet with no reward/stake address, or not fully synced), `[0]` is `undefined` and flows unchecked into `getBech32AddressFromHex` → `hexToBytes` → `Buffer.from(undefined, 'hex')`, throwing an opaque:

```
TypeError: The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type undefined
```

## Fix

- Add an explicit guard on the reward-address fallback with a clear, actionable message (\"No reward address available — enter an address manually\").
- Rethrow the original `error` instead of `throw new Error(error)`, which double-wrapped into `Error: Error: ...` and hid the real message/stack.

The fallback behavior itself is unchanged.