### PR TITLE
fix: guard unchecked wallet data and credential parsing (v2.2.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dapp-example",
-  "version": "0.2.1",
+  "version": "2.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dapp-example",
-      "version": "0.2.1",
+      "version": "2.2.4",
       "dependencies": {
         "@emurgo/cardano-serialization-lib-browser": "14.1.2",
         "@emurgo/cip4-js": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dapp-example",
-  "version": "2.2.0",
+  "version": "2.2.4",
   "private": true,
   "dependencies": {
     "@emurgo/cardano-serialization-lib-browser": "14.1.2",

--- a/src/components/cards/staking/withdrawCard.js
+++ b/src/components/cards/staking/withdrawCard.js
@@ -14,6 +14,7 @@ import ApiCardWithModal from '../apiCardWithModal'
 import {ModalWindowContent} from '../../ui-constants'
 import {useEffect, useState} from 'react'
 import {fetchAccountInfo, getTxBuilderWithWithdrawal} from './logic/withdraw'
+import {firstOrThrow} from '../../../utils/helpFunctions'
 import CheckboxWithLabel from '../../checkboxWithLabel'
 
 const WithdrawCard = ({api, onRawResponse, onResponse, onWaiting}) => {
@@ -47,7 +48,7 @@ const WithdrawCard = ({api, onRawResponse, onResponse, onWaiting}) => {
     setShowSuccessInfo(false)
 
     try {
-      const rewardAddressHex = (await api?.getRewardAddresses())[0]
+      const rewardAddressHex = firstOrThrow(await api?.getRewardAddresses(), 'No reward address available from wallet')
       const delegationInfoResponse = await fetchAccountInfo(networkType, rewardAddressHex)
 
       if (!delegationInfoResponse.ok) {
@@ -85,7 +86,9 @@ const WithdrawCard = ({api, onRawResponse, onResponse, onWaiting}) => {
       onWaiting(true)
       // build withdraw
       const pubStakeKey = await api?.cip95.getRegisteredPubStakeKeys()
-      const stakeKeyHash = getPublicKeyFromHex(pubStakeKey[0]).hash().to_hex()
+      const stakeKeyHash = getPublicKeyFromHex(
+        firstOrThrow(pubStakeKey, 'No registered stake key available from wallet'),
+      ).hash().to_hex()
       const txBuilderWithWithdrawal = await getTxBuilderWithWithdrawal(stakeKeyHash, networkType, rewardAmount)
       const utxos = await api?.getUtxos()
 

--- a/src/components/tabs/subtabs/NFTTab.js
+++ b/src/components/tabs/subtabs/NFTTab.js
@@ -16,6 +16,7 @@ import {
   toInt,
 } from '../../../utils/cslTools'
 import {CONNECTED} from '../../../utils/connectionStates'
+import {firstOrThrow} from '../../../utils/helpFunctions'
 import SelectWithLabel from '../../selectWithLabel'
 import InputWithLabel from '../../inputWithLabel'
 
@@ -164,7 +165,7 @@ const NFTTab = () => {
       console.debug(`[NFTTab][mint] changeAddress -> ${changeAddress}`)
       const wasmChangeAddress = getAddressFromBytes(changeAddress)
       const usedAddresses = await api?.getUsedAddresses()
-      const usedAddress = getAddressFromBytes(usedAddresses[0])
+      const usedAddress = getAddressFromBytes(firstOrThrow(usedAddresses, 'No used address available from wallet'))
       const pubkeyHash = getPubKeyHash(usedAddress)
       const wasmNativeScript = getNativeScript(pubkeyHash)
       const scriptHashHex = wasmNativeScript.hash().to_hex()

--- a/src/components/tabs/subtabs/constitCommCertsTab.js
+++ b/src/components/tabs/subtabs/constitCommCertsTab.js
@@ -11,12 +11,12 @@ const ConstitCommCertsTab = ({api, onWaiting, onError, getters, setters}) => {
       try {
         return getCslCredentialFromBech32(input)
       } catch (err2) {
-        onWaiting(false)
-        console.error(
-          `Error in parsing credential, not Hex or Bech32: ${JSON.stringify(err1)}, ${JSON.stringify(err2)}`,
+        // Throw instead of returning null so the caller's try/catch handles cleanup
+        // (onWaiting/onError), rather than feeding null into CSL and crashing
+        // with the opaque `expected instance of Fe`.
+        throw new Error(
+          `Invalid credential — not valid Hex or Bech32: ${JSON.stringify(err1)}, ${JSON.stringify(err2)}`,
         )
-        onError()
-        return null
       }
     }
   }

--- a/src/components/tabs/subtabs/govBasicFunctionsTab.js
+++ b/src/components/tabs/subtabs/govBasicFunctionsTab.js
@@ -22,12 +22,12 @@ const GovBasicFunctionsTab = ({api, onWaiting, onError, getters, setters}) => {
       try {
         return getCslCredentialFromBech32(input)
       } catch (err2) {
-        onWaiting(false)
-        console.error(
-          `Error in parsing credential, not Hex or Bech32: ${JSON.stringify(err1)}, ${JSON.stringify(err2)}`,
+        // Throw instead of returning null so the caller's try/catch handles cleanup
+        // (onWaiting/onError), rather than feeding null into CSL and crashing
+        // with the opaque `expected instance of Fe`.
+        throw new Error(
+          `Invalid credential — not valid Hex or Bech32: ${JSON.stringify(err1)}, ${JSON.stringify(err2)}`,
         )
-        onError()
-        return null
       }
     }
   }

--- a/src/components/tabs/subtabs/tokenTab.js
+++ b/src/components/tabs/subtabs/tokenTab.js
@@ -14,6 +14,7 @@ import {
   toInt,
 } from '../../../utils/cslTools'
 import {CONNECTED} from '../../../utils/connectionStates'
+import {firstOrThrow} from '../../../utils/helpFunctions'
 import InputWithLabel from '../../inputWithLabel'
 
 const TokenTab = () => {
@@ -109,7 +110,7 @@ const TokenTab = () => {
     const wasmChangeAddress = getAddressFromBytes(changeAddress)
     try {
       const usedAddresses = await api?.getUsedAddresses()
-      const usedAddress = getAddressFromBytes(usedAddresses[0])
+      const usedAddress = getAddressFromBytes(firstOrThrow(usedAddresses, 'No used address available from wallet'))
       const pubkeyHash = getPubKeyHash(usedAddress)
       const wasmNativeScript = getNativeScript(pubkeyHash)
 

--- a/src/utils/helpFunctions.js
+++ b/src/utils/helpFunctions.js
@@ -1,5 +1,16 @@
 import {getCslValue, getUtxoFromHex, getBech32AddressFromHex, getPublicKeyFromHex} from './cslTools'
 
+// Returns the first element of a wallet-returned array, or throws a clear error
+// if the wallet returned nothing. Prevents `undefined` from flowing into CSL
+// byte/hex conversions, which otherwise fail with an opaque TypeError.
+export const firstOrThrow = (arr, message) => {
+  const value = arr?.[0]
+  if (value === undefined || value === null) {
+    throw new Error(message)
+  }
+  return value
+}
+
 export const getBalance = async (api) => {
   const hexBalance = await api.getBalance()
   const cslValue = getCslValue(hexBalance)


### PR DESCRIPTION
## Problem

Several places assumed wallet-returned data would always be present, letting \`undefined\`/\`null\` flow into the Cardano serialization lib (CSL) and crash with opaque errors:

- \`Buffer.from(undefined)\` → \`TypeError: The first argument must be one of type string, Buffer, ...\` when a wallet array (reward address, used address, registered stake key) came back empty.
- \`expected instance of Fe\` when \`handleInputCreds\` returned \`null\` on a bad/empty credential and the caller passed it straight into a CSL cert builder.

## Changes

**Wallet array guards**
- New \`firstOrThrow(arr, message)\` helper in \`utils/helpFunctions.js\`.
- Applied to the unchecked \`[0]\` sites:
  - \`staking/withdrawCard.js\` — reward address + registered stake key
  - \`tabs/subtabs/tokenTab.js\` — used address
  - \`tabs/subtabs/NFTTab.js\` — used address

**Credential parsing**
- \`handleInputCreds\` now **throws** a clear \`Invalid credential — not valid Hex or Bech32\` error instead of returning \`null\`. Every consumer already wraps the call in \`try/catch\` that runs \`onWaiting(false)\` + \`onError()\`, so cleanup still happens and \`null\` never reaches CSL. Applied to both definitions (\`govBasicFunctionsTab.js\`, \`constitCommCertsTab.js\`), fixing all 7 gov-action panels.

**Version**
- Bump to \`2.2.4\` (npm install also reconciled a pre-existing \`package-lock.json\` root drift: \`0.2.1\` → \`2.2.4\`).

## Result

Empty/invalid input now produces a clear error message and clean UI error state instead of an opaque CSL crash.