### PR TITLE
Project improvements: correctness fixes, DRY refactors, logger, tests/CI, tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Copy to `.env` to override defaults. Only variables prefixed with REACT_APP_
+# are exposed to the app (Create React App convention).
+
+# Enable verbose debug/log output in production builds.
+# - During local development (`npm start`) logs are ON by default regardless.
+# - In production builds logs are OFF unless this is set to "true".
+# - You can also toggle logs at runtime from the browser console, without
+#   rebuilding: dappLogs.on() / dappLogs.off() / dappLogs.toggle().
+REACT_APP_DEBUG=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,10 @@ jobs:
         run: |
           npm i
 
+      - name: Create production .env
+        run: |
+          echo "REACT_APP_DEBUG=false" > .env
+
       - name: Build
         run: |
           npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read .nvmrc
+        id: nvm
+        run: echo "version=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '${{ steps.nvm.outputs.version }}'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Run tests
+        run: npm run test:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,11 @@ jobs:
       - name: Install dependencies
         run: npm i
 
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Lint
+        run: npm run lint
+
       - name: Run tests
         run: npm run test:ci

--- a/.prettierrc
+++ b/.prettierrc
@@ -7,8 +7,5 @@
   "semi": false,
   "singleQuote": true,
   "bracketSpacing": false,
-  "arrowParens": "always",
-  "importOrder": ["^@(.*)$", "^[./]" ],
-  "importOrderSeparation": true,
-  "importOrderSortSpecifiers": true
+  "arrowParens": "always"
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,90 @@
 # dapp-example
 
-The project is created with purpose to show how to work with yoroi dApp-connector.
+A simple, multi-chain example dApp that shows how to interact with wallet
+connectors — built for clarity, learning, testing, and extension.
 
-It may not look good but it works and can be used as an example to other projects how to interact with the dApp-connector.
+Live demo: https://dapp-example.yoroiwallet.com/
 
-You can find the dApp on this link https://dapp-example.yoroiwallet.com/
+> It may not look fancy, but it works and is meant as a reference for other
+> projects on how to talk to wallet dApp-connectors.
+
+## Supported chains
+
+- **Cardano** (CIP-30) — live, via browser wallet extensions (e.g. Yoroi)
+- **Ethereum** (EIP-1193) — live, via `window.ethereum`
+- **Bitcoin** — planned (provider is currently a stub)
+
+## Tech stack
+
+- React 18 (functional components + hooks), JavaScript only (no TypeScript)
+- Tailwind CSS + Material Tailwind
+- Create React App + craco
+- Cardano serialization via `@emurgo/cardano-serialization-lib-browser`
+
+## Getting started
+
+Prerequisites: Node.js (see [`.nvmrc`](./.nvmrc)) and npm.
+
+```bash
+npm install      # install dependencies
+npm start        # run the dev server at http://localhost:3000
+npm run build    # production build into ./build
+```
+
+A Cardano and/or Ethereum browser wallet extension is required to exercise the
+connect flows.
+
+## Available scripts
+
+| Script | Description |
+| --- | --- |
+| `npm start` | Start the development server |
+| `npm run build` | Production build |
+| `npm test` | Run tests in watch mode |
+| `npm run test:ci` | Run tests once (CI mode) |
+| `npm run lint` | Lint `src` with ESLint |
+| `npm run lint:fix` | Lint and auto-fix |
+| `npm run format` | Format `src` with Prettier |
+| `npm run format:check` | Check formatting without writing |
+
+## Project structure
+
+```
+src/
+  hooks/        # Providers (one per chain) + network toggle + shared hooks
+  components/   # UI: access buttons, tabs, cards, shared inputs
+  utils/        # Helpers and blockchain utilities (cslTools, ethereumUtils, ...)
+```
+
+Each chain follows the same flow: **Provider → Access Button → Main Tab →
+Subtabs → Cards**. See [`CLAUDE.md`](./CLAUDE.md) for the full architecture and
+conventions.
+
+## Logging
+
+The app uses a small debug-gated logger (`src/utils/logger.js`):
+
+- `debug` / `log` / `info` print only in development, or in a production build
+  started with `REACT_APP_DEBUG=true` (see [`.env.example`](./.env.example)).
+- `warn` / `error` always print.
+
+You can toggle logs live from the browser console — no rebuild needed:
+
+```js
+dappLogs.on()      // enable and remember across reloads
+dappLogs.off()     // disable and remember across reloads
+dappLogs.toggle()  // flip current state
+dappLogs.status()  // -> true | false
+dappLogs.reset()   // forget the override, fall back to the build default
+```
+
+## Testing
+
+Tests use Jest + React Testing Library (via CRA). Run `npm run test:ci` for a
+single pass, or `npm test` to watch. Tests and linting run in CI on pushes to
+`main` and on pull requests.
+
+## Configuration
+
+Copy [`.env.example`](./.env.example) to `.env` to override defaults. Only
+variables prefixed with `REACT_APP_` are exposed to the app.

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@rollup/plugin-terser": "^0.4.4",
         "autoprefixer": "^10.4.8",
         "postcss": "^8.4.16",
+        "prettier": "^3.9.4",
         "tailwindcss": "^3.1.8"
       }
     },
@@ -18711,6 +18712,22 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-bytes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dapp-example",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dapp-example",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "dependencies": {
         "@emurgo/cardano-serialization-lib-browser": "14.1.2",
         "@emurgo/cip4-js": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "start": "craco start",
     "build": "CI=false && craco build",
     "test": "craco test",
+    "test:ci": "CI=true craco test",
     "eject": "craco eject"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dapp-example",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "private": true,
   "dependencies": {
     "@emurgo/cardano-serialization-lib-browser": "14.1.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@rollup/plugin-terser": "^0.4.4",
     "autoprefixer": "^10.4.8",
     "postcss": "^8.4.16",
+    "prettier": "^3.9.4",
     "tailwindcss": "^3.1.8"
   },
   "scripts": {
@@ -37,6 +38,10 @@
     "build": "CI=false && craco build",
     "test": "craco test",
     "test:ci": "CI=true craco test",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write \"src/**/*.js\"",
+    "format:check": "prettier --check \"src/**/*.js\"",
     "eject": "craco eject"
   },
   "eslintConfig": {

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React, {useEffect} from 'react'
 import AccessButton from './components/accessButton'
 import MainTab from './components/tabs/mainTab'
 import TabsComponent from './components/tabs/tabsComponent'
-import useYoroi from './hooks/yoroiProvider'
+import useCardano from './hooks/cardanoProvider'
 import useNetwork, {NETWORK_CARDANO, NETWORK_ETHEREUM} from './hooks/networkProvider'
 import BitcoinAccessButton from './components/bitcoinAccessButton'
 import BitcoinMainTab from './components/tabs/bitcoinMainTab'
@@ -24,7 +24,7 @@ import EthTransactionsTab from './components/tabs/subtabs/ethTransactionsTab'
 import Erc20Tab from './components/tabs/subtabs/erc20Tab'
 
 const App = () => {
-  const {connectionState, selectedWallet, setConnectionState, setConnectionStateFalse} = useYoroi()
+  const {connectionState, selectedWallet, setConnectionState, setConnectionStateFalse} = useCardano()
   const {activeNetwork} = useNetwork()
   const isWalletConnected = connectionState === CONNECTED
   const isNoProvider = connectionState === NO_PROVIDER

--- a/src/App.js
+++ b/src/App.js
@@ -1,3 +1,4 @@
+import logger from './utils/logger'
 import React, {useEffect} from 'react'
 import AccessButton from './components/accessButton'
 import MainTab from './components/tabs/mainTab'
@@ -42,7 +43,7 @@ const App = () => {
 
   useEffect(() => {
     const getConnectionState = async () => {
-      console.debug(`[dApp][App] Checking connection works`)
+      logger.debug(`[dApp][App] Checking connection works`)
       try {
         const walletObject = window.cardano[selectedWallet]
         const conState = await walletStateWithTimeout(walletObject, 10000)
@@ -54,14 +55,14 @@ const App = () => {
         }
       } catch (error) {
         setConnectionStateFalse()
-        console.error(error)
+        logger.error(error)
       }
     }
 
     if (isWalletConnected) {
       const connectionTimer = setInterval(getConnectionState, 10000)
       return () => {
-        console.debug(`[dApp][App] Checking connection is stopped`)
+        logger.debug(`[dApp][App] Checking connection is stopped`)
         clearInterval(connectionTimer)
       }
     }

--- a/src/components/accessButton.js
+++ b/src/components/accessButton.js
@@ -3,6 +3,7 @@ import React from 'react'
 import useCardano from '../hooks/cardanoProvider'
 import {IN_PROGRESS} from '../utils/connectionStates'
 import WalletsModal from './walletsModal'
+import AccessButtonShell from './accessButtonShell'
 
 const AccessButton = () => {
   const {api, connectionState, availableWallets, selectedWallet} = useCardano()
@@ -20,27 +21,25 @@ const AccessButton = () => {
   }
 
   return (
-    <div className="mx-auto bg-gray-900">
-      <div className="grid justify-items-center py-3">
-        {api ? (
-          <div className="flex items-center justify-center gap-3 py-5">
-            <img src={getWalletIcon()} alt="wallet icon" className="w-10 sm:w-14 lg:w-16" />
-            <div className="text-base sm:text-xl font-bold tracking-tight text-white text-center">
-              <div>Connected To {getWalletName()}</div>
-              <div className="py-1 text-sm sm:text-base">anonymous wallet</div>
-            </div>
+    <AccessButtonShell>
+      {api ? (
+        <div className="flex items-center justify-center gap-3 py-5">
+          <img src={getWalletIcon()} alt="wallet icon" className="w-10 sm:w-14 lg:w-16" />
+          <div className="text-base sm:text-xl font-bold tracking-tight text-white text-center">
+            <div>Connected To {getWalletName()}</div>
+            <div className="py-1 text-sm sm:text-base">anonymous wallet</div>
           </div>
-        ) : connectionState === IN_PROGRESS ? (
-          <div className="pt-5 pb-5 text-m font-bold tracking-tight text-green-500">
-            <label>Wallet connecting is in progress ...</label>
-          </div>
-        ) : (
-          <div>
-            <WalletsModal />
-          </div>
-        )}
-      </div>
-    </div>
+        </div>
+      ) : connectionState === IN_PROGRESS ? (
+        <div className="pt-5 pb-5 text-m font-bold tracking-tight text-green-500">
+          <label>Wallet connecting is in progress ...</label>
+        </div>
+      ) : (
+        <div>
+          <WalletsModal />
+        </div>
+      )}
+    </AccessButtonShell>
   )
 }
 

--- a/src/components/accessButton.js
+++ b/src/components/accessButton.js
@@ -1,3 +1,4 @@
+import logger from '../utils/logger'
 import React from 'react'
 import useCardano from '../hooks/cardanoProvider'
 import {IN_PROGRESS} from '../utils/connectionStates'
@@ -5,7 +6,7 @@ import WalletsModal from './walletsModal'
 
 const AccessButton = () => {
   const {api, connectionState, availableWallets, selectedWallet} = useCardano()
-  console.log(`[dApp][AccessButton] available wallets: ${availableWallets.length}`)
+  logger.log(`[dApp][AccessButton] available wallets: ${availableWallets.length}`)
 
   const getWalletIcon = () => {
     return window.cardano[selectedWallet].icon

--- a/src/components/accessButton.js
+++ b/src/components/accessButton.js
@@ -1,10 +1,10 @@
 import React from 'react'
-import useYoroi from '../hooks/yoroiProvider'
+import useCardano from '../hooks/cardanoProvider'
 import {IN_PROGRESS} from '../utils/connectionStates'
 import WalletsModal from './walletsModal'
 
 const AccessButton = () => {
-  const {api, connectionState, availableWallets, selectedWallet} = useYoroi()
+  const {api, connectionState, availableWallets, selectedWallet} = useCardano()
   console.log(`[dApp][AccessButton] available wallets: ${availableWallets.length}`)
 
   const getWalletIcon = () => {

--- a/src/components/accessButtonShell.js
+++ b/src/components/accessButtonShell.js
@@ -1,0 +1,10 @@
+import React from 'react'
+
+// Shared chrome for each chain's access button: dark background + centered grid.
+const AccessButtonShell = ({children, innerClassName = 'grid justify-items-center py-3'}) => (
+  <div className="mx-auto bg-gray-900">
+    <div className={innerClassName}>{children}</div>
+  </div>
+)
+
+export default AccessButtonShell

--- a/src/components/bitcoinAccessButton.js
+++ b/src/components/bitcoinAccessButton.js
@@ -1,18 +1,14 @@
-import React from 'react'
+import AccessButtonShell from './accessButtonShell'
 
-const BitcoinAccessButton = () => {
-  return (
-    <div className="mx-auto bg-gray-900">
-      <div className="grid justify-items-center py-3">
-        <button
-          className="rounded-md bg-orange-600 py-5 px-5 disabled:opacity-50 text-white font-semibold cursor-not-allowed"
-          disabled
-        >
-          Bitcoin (Coming Soon)
-        </button>
-      </div>
-    </div>
-  )
-}
+const BitcoinAccessButton = () => (
+  <AccessButtonShell>
+    <button
+      className="rounded-md bg-orange-600 py-5 px-5 disabled:opacity-50 text-white font-semibold cursor-not-allowed"
+      disabled
+    >
+      Bitcoin (Coming Soon)
+    </button>
+  </AccessButtonShell>
+)
 
 export default BitcoinAccessButton

--- a/src/components/cards/apiCard.js
+++ b/src/components/cards/apiCard.js
@@ -1,5 +1,13 @@
 import React from 'react'
 
+// Static map so Tailwind's JIT keeps these classes — `h-${height}` would be
+// built at runtime and purged from the production build.
+const HEIGHT_CLASSES = {
+  10: 'h-10',
+  16: 'h-16',
+  24: 'h-24',
+}
+
 const ApiCard = (props) => {
   const {apiName, clickFunction, color, height} = props
 
@@ -7,7 +15,7 @@ const ApiCard = (props) => {
   if (color != null) {
     localColor = color
   }
-  const localHeight = height == null ? 'h-16' : `h-${height}`
+  const localHeight = HEIGHT_CLASSES[height] || 'h-16'
 
   const localClassName = `w-full ${localHeight} ${localColor} disabled:bg-gray-800 rounded-lg text-white text-lg`
 

--- a/src/components/cards/apiCard.test.js
+++ b/src/components/cards/apiCard.test.js
@@ -1,0 +1,28 @@
+import {render, screen, fireEvent} from '@testing-library/react'
+import ApiCard from './apiCard'
+
+describe('ApiCard', () => {
+  it('renders the apiName as a button and fires clickFunction', () => {
+    const onClick = jest.fn()
+    render(<ApiCard apiName="Do Thing" clickFunction={onClick} />)
+
+    const button = screen.getByRole('button', {name: 'Do Thing'})
+    fireEvent.click(button)
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies a mapped height class', () => {
+    render(<ApiCard apiName="Tall" clickFunction={() => {}} height={24} />)
+    expect(screen.getByRole('button', {name: 'Tall'}).className).toContain('h-24')
+  })
+
+  it('falls back to h-16 for an unmapped height', () => {
+    render(<ApiCard apiName="Default" clickFunction={() => {}} height={999} />)
+    expect(screen.getByRole('button', {name: 'Default'}).className).toContain('h-16')
+  })
+
+  it('uses the provided color class when given', () => {
+    render(<ApiCard apiName="Red" clickFunction={() => {}} color="bg-red-700" />)
+    expect(screen.getByRole('button', {name: 'Red'}).className).toContain('bg-red-700')
+  })
+})

--- a/src/components/cards/apiCardWithModal.js
+++ b/src/components/cards/apiCardWithModal.js
@@ -30,8 +30,8 @@ export const ApiCardWithModal = (props) => {
   }
 
   return (
-    <Popup 
-      trigger={<button {...buttonProps}>{buttonLabel}</button>} 
+    <Popup
+      trigger={<button {...buttonProps}>{buttonLabel}</button>}
       {...{modal, nested, overlayStyle}}
       contentStyle={contentStyle}
     >
@@ -54,16 +54,14 @@ export const ApiCardWithModal = (props) => {
             </div>
           </div>
           {/* content section */}
-          <div className="py-5 flex-grow overflow-y-auto">
-            {children}
-          </div>
+          <div className="py-5 flex-grow overflow-y-auto">{children}</div>
           {/* end of content section*/}
           {/* confirmation button */}
           <div className="flex">
             <div className="flex-auto mb-2 mt-3 mx-2">
               <button
                 className={`w-full py-1 rounded-md text-xl text-white font-semibold ${
-                  btnDisabled === true 
+                  btnDisabled === true
                     ? 'bg-gray-500 cursor-not-allowed'
                     : 'bg-orange-700 hover:bg-orange-800 active:bg-orange-500'
                 }`}

--- a/src/components/cards/apiCardWithModal.js
+++ b/src/components/cards/apiCardWithModal.js
@@ -1,13 +1,14 @@
+import logger from '../../utils/logger'
 import Popup from 'reactjs-popup'
 
 export const ApiCardWithModal = (props) => {
   const {buttonLabel, clickFunction, halfOpacity, children, btnDisabled} = props
 
   const handleActionAndClose = (closeFunc) => {
-    console.log(`[dApp][ApiCardWithModal][${buttonLabel}] is called`)
+    logger.log(`[dApp][ApiCardWithModal][${buttonLabel}] is called`)
     clickFunction()
     closeFunc()
-    console.log(`[dApp][ApiCardWithModal][${buttonLabel}] is closed`)
+    logger.log(`[dApp][ApiCardWithModal][${buttonLabel}] is closed`)
   }
 
   const overlayStyle = {background: 'rgba(0,0,0,0.75)'}

--- a/src/components/cards/buildTransactionCard.js
+++ b/src/components/cards/buildTransactionCard.js
@@ -43,11 +43,7 @@ const BuildTransactionCard = ({api, onRawResponse, onResponse, onWaiting}) => {
         for (let i = 0; i < wasmUtxos.len(); i++) {
           const wasmUtxo = wasmUtxos.get(i)
           const output = wasmUtxo.output()
-          txBuilder.add_regular_input(
-            output.address(),
-            wasmUtxo.input(),
-            output.amount(),
-          )
+          txBuilder.add_regular_input(output.address(), wasmUtxo.input(), output.amount())
         }
 
         // Sending everything to the receiver
@@ -107,7 +103,9 @@ const BuildTransactionCard = ({api, onRawResponse, onResponse, onWaiting}) => {
         <InputWithLabel
           inputName="Receiver address"
           inputValue={buildTransactionInput.address}
-          onChangeFunction={(event) => setBuildTransactionInput({...buildTransactionInput, address: event.target.value})}
+          onChangeFunction={(event) =>
+            setBuildTransactionInput({...buildTransactionInput, address: event.target.value})
+          }
         />
       </div>
     </ApiCardWithModal>

--- a/src/components/cards/buildTransactionCard.js
+++ b/src/components/cards/buildTransactionCard.js
@@ -9,7 +9,8 @@ import {
   getAddressFromBech32,
 } from '../../utils/cslTools'
 import ApiCardWithModal from './apiCardWithModal'
-import {ModalWindowContent, CommonStyles} from '../ui-constants'
+import {ModalWindowContent} from '../ui-constants'
+import InputWithLabel from '../inputWithLabel'
 import CheckboxWithLabel from '../checkboxWithLabel'
 
 const BuildTransactionCard = ({api, onRawResponse, onResponse, onWaiting}) => {
@@ -82,21 +83,15 @@ const BuildTransactionCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   return (
     <ApiCardWithModal {...apiProps}>
       <div className={ModalWindowContent.contentPadding}>
-        <div>
-          <label htmlFor="amount" className={ModalWindowContent.contentLabelStyle}>
-            Amount
-          </label>
-          <input
-            type="number"
-            min="1000000"
-            id="amount"
-            className={isAmountInputDisabled ? CommonStyles.inputStylesDisabled : CommonStyles.inputStyles}
-            placeholder=""
-            value={buildTransactionInput.amount}
-            onChange={(event) => setBuildTransactionInput({...buildTransactionInput, amount: event.target.value})}
-            disabled={isAmountInputDisabled}
-          />
-        </div>
+        <InputWithLabel
+          inputName="Amount"
+          type="number"
+          min="1000000"
+          inputValue={buildTransactionInput.amount}
+          onChangeFunction={(event) => setBuildTransactionInput({...buildTransactionInput, amount: event.target.value})}
+          disabled={isAmountInputDisabled}
+          wrapperClassName=""
+        />
         <CheckboxWithLabel
           currentState={buildTransactionInput.sendAll}
           onChangeFunc={(event) => {
@@ -109,19 +104,11 @@ const BuildTransactionCard = ({api, onRawResponse, onResponse, onWaiting}) => {
           name="sendAll"
           labelText="Send all (no change)"
         />
-        <div className="mt-3">
-          <label htmlFor="receiverAddress" className={ModalWindowContent.contentLabelStyle}>
-            Receiver address
-          </label>
-          <input
-            type="text"
-            id="receiverAddress"
-            className={CommonStyles.inputStyles}
-            placeholder=""
-            value={buildTransactionInput.address}
-            onChange={(event) => setBuildTransactionInput({...buildTransactionInput, address: event.target.value})}
-          />
-        </div>
+        <InputWithLabel
+          inputName="Receiver address"
+          inputValue={buildTransactionInput.address}
+          onChangeFunction={(event) => setBuildTransactionInput({...buildTransactionInput, address: event.target.value})}
+        />
       </div>
     </ApiCardWithModal>
   )

--- a/src/components/cards/cip95BuildSignSubmitCard.js
+++ b/src/components/cards/cip95BuildSignSubmitCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import {
   getAddressFromBech32,
   getCslUtxos,
@@ -17,7 +18,7 @@ const Cip95BuildSignSubmitCard = (props) => {
   const errorHappen = (errorMessage) => {
     onWaiting(false)
     onError()
-    console.error(errorMessage)
+    logger.error(errorMessage)
   }
 
   const buildSignSubmit = async () => {
@@ -55,7 +56,7 @@ const Cip95BuildSignSubmitCard = (props) => {
       const wasmUnsignedTransaction = txBuilder.build_tx()
       // sign Tx
       const fixedTx = getFixedTxFromBytes(wasmUnsignedTransaction.to_bytes())
-      console.log('[Cip95BuildSignSubmitCard] Unsigned Tx:', fixedTx.to_hex())
+      logger.log('[Cip95BuildSignSubmitCard] Unsigned Tx:', fixedTx.to_hex())
       const witnessHex = await api?.signTx(fixedTx.to_hex())
       const wasmWitnessSet = getTransactionWitnessSetFromBytes(witnessHex)
       const vkeys = wasmWitnessSet.vkeys()
@@ -63,9 +64,9 @@ const Cip95BuildSignSubmitCard = (props) => {
         fixedTx.add_vkey_witness(vkeys.get(i))
       }
       const signedTxHex = fixedTx.to_hex()
-      console.log('Signed Tx:', signedTxHex)
+      logger.log('Signed Tx:', signedTxHex)
       const txId = await api?.submitTx(signedTxHex)
-      console.log('The transaction is sent:', txId)
+      logger.log('The transaction is sent:', txId)
     } catch (e) {
       errorHappen(e)
     } finally {

--- a/src/components/cards/cip95SignDataCard.js
+++ b/src/components/cards/cip95SignDataCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React, {useState} from 'react'
 import ApiCardWithModal from './apiCardWithModal'
 import {Buffer} from 'buffer'
@@ -35,7 +36,7 @@ const Cip95SignDataCard = ({api, onRawResponse, onResponse, onWaiting}) => {
       } else {
         onResponse(error)
       }
-      console.error(error)
+      logger.error(error)
     } finally {
       onWaiting(false)
     }

--- a/src/components/cards/cip95SignDataCard.js
+++ b/src/components/cards/cip95SignDataCard.js
@@ -2,7 +2,8 @@ import logger from '../../utils/logger'
 import React, {useState} from 'react'
 import ApiCardWithModal from './apiCardWithModal'
 import {Buffer} from 'buffer'
-import {CommonStyles, ModalWindowContent} from '../ui-constants'
+import {ModalWindowContent} from '../ui-constants'
+import InputWithLabel from '../inputWithLabel'
 
 const Cip95SignDataCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   const [message, setMessage] = useState('')
@@ -50,32 +51,17 @@ const Cip95SignDataCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   return (
     <ApiCardWithModal {...apiProps}>
       <div className={ModalWindowContent.contentPadding}>
-        <div>
-          <label htmlFor="addressOrDRepID" className={ModalWindowContent.contentLabelStyle}>
-            Address or DRepID (HEX)
-          </label>
-          <input
-            type="text"
-            id="addressOrDRepID"
-            className={CommonStyles.inputStyles}
-            placeholder=""
-            value={addressOrDRep}
-            onChange={(event) => setAddressOrDRep(event.target.value)}
-          />
-        </div>
-        <div className="mt-3">
-          <label htmlFor="signMessage" className={ModalWindowContent.contentLabelStyle}>
-            Message
-          </label>
-          <input
-            type="text"
-            id="signMessage"
-            className={CommonStyles.inputStyles}
-            placeholder=""
-            value={message}
-            onChange={(event) => setMessage(event.target.value)}
-          />
-        </div>
+        <InputWithLabel
+          inputName="Address or DRepID (HEX)"
+          inputValue={addressOrDRep}
+          onChangeFunction={(event) => setAddressOrDRep(event.target.value)}
+          wrapperClassName=""
+        />
+        <InputWithLabel
+          inputName="Message"
+          inputValue={message}
+          onChangeFunction={(event) => setMessage(event.target.value)}
+        />
       </div>
     </ApiCardWithModal>
   )

--- a/src/components/cards/cip95getPubDRepKeyCard.js
+++ b/src/components/cards/cip95getPubDRepKeyCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 import { getPublicKeyFromHex } from '../../utils/cslTools'
@@ -22,7 +23,7 @@ const Cip95GetPubDRepKeyCard = ({api, onRawResponse, onResponse, onWaiting}) => 
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.log(e)
+        logger.log(e)
       })
   }
 

--- a/src/components/cards/cip95getPubDRepKeyCard.js
+++ b/src/components/cards/cip95getPubDRepKeyCard.js
@@ -1,31 +1,19 @@
-import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 import { getPublicKeyFromHex } from '../../utils/cslTools'
+import runApiCall from '../../utils/runApiCall'
 
 const Cip95GetPubDRepKeyCard = ({api, onRawResponse, onResponse, onWaiting}) => {
-  const getPubDRepKeyClick = () => {
-    onWaiting(true)
-    api?.cip95
-      .getPubDRepKey()
-      .then((pubDRepKey) => {
-        onWaiting(false)
-        onRawResponse(pubDRepKey)
+  const getPubDRepKeyClick = () =>
+    runApiCall(() => api.cip95.getPubDRepKey(), {onRawResponse, onResponse, onWaiting}, {
+      parse: (pubDRepKey) => {
         const dRepID = getPublicKeyFromHex(pubDRepKey).hash()
-        const dRepIDHex = dRepID.to_hex()
-        const dRepIDBech32 = dRepID.to_bech32('drep')
-        onResponse({
-          dRepIDHex: dRepIDHex,
-          dRepIDBech32: dRepIDBech32,
-        })
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.log(e)
-      })
-  }
+        return {
+          dRepIDHex: dRepID.to_hex(),
+          dRepIDBech32: dRepID.to_bech32('drep'),
+        }
+      },
+    })
 
   const apiProps = {
     apiName: 'getPubDRepKey',

--- a/src/components/cards/cip95getPubDRepKeyCard.js
+++ b/src/components/cards/cip95getPubDRepKeyCard.js
@@ -1,19 +1,23 @@
 import React from 'react'
 import ApiCard from './apiCard'
-import { getPublicKeyFromHex } from '../../utils/cslTools'
+import {getPublicKeyFromHex} from '../../utils/cslTools'
 import runApiCall from '../../utils/runApiCall'
 
 const Cip95GetPubDRepKeyCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   const getPubDRepKeyClick = () =>
-    runApiCall(() => api.cip95.getPubDRepKey(), {onRawResponse, onResponse, onWaiting}, {
-      parse: (pubDRepKey) => {
-        const dRepID = getPublicKeyFromHex(pubDRepKey).hash()
-        return {
-          dRepIDHex: dRepID.to_hex(),
-          dRepIDBech32: dRepID.to_bech32('drep'),
-        }
+    runApiCall(
+      () => api.cip95.getPubDRepKey(),
+      {onRawResponse, onResponse, onWaiting},
+      {
+        parse: (pubDRepKey) => {
+          const dRepID = getPublicKeyFromHex(pubDRepKey).hash()
+          return {
+            dRepIDHex: dRepID.to_hex(),
+            dRepIDBech32: dRepID.to_bech32('drep'),
+          }
+        },
       },
-    })
+    )
 
   const apiProps = {
     apiName: 'getPubDRepKey',

--- a/src/components/cards/cip95getRegisteredPubStakeKeysCard.js
+++ b/src/components/cards/cip95getRegisteredPubStakeKeysCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 import { getPublicKeyFromHex } from '../../utils/cslTools'
@@ -8,7 +9,7 @@ const Cip95GetRegisteredPubStakeKeysCard = ({api, onRawResponse, onResponse, onW
     api?.cip95
       .getRegisteredPubStakeKeys()
       .then((regPubStakeKeys) => {
-        console.log('regPubStakeKeys: ', regPubStakeKeys)
+        logger.log('regPubStakeKeys: ', regPubStakeKeys)
         onWaiting(false)
         onRawResponse(regPubStakeKeys)
         if (regPubStakeKeys.length < 1) {
@@ -23,7 +24,7 @@ const Cip95GetRegisteredPubStakeKeysCard = ({api, onRawResponse, onResponse, onW
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.log(e)
+        logger.log(e)
       })
   }
 

--- a/src/components/cards/cip95getRegisteredPubStakeKeysCard.js
+++ b/src/components/cards/cip95getRegisteredPubStakeKeysCard.js
@@ -1,7 +1,7 @@
 import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
-import { getPublicKeyFromHex } from '../../utils/cslTools'
+import {getPublicKeyFromHex} from '../../utils/cslTools'
 
 const Cip95GetRegisteredPubStakeKeysCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   const getRegisteredPubStakeKeysClick = () => {

--- a/src/components/cards/cip95getUnregisteredPubStakeKeysCard.js
+++ b/src/components/cards/cip95getUnregisteredPubStakeKeysCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 import { getPublicKeyFromHex } from '../../utils/cslTools'
@@ -8,7 +9,7 @@ const Cip95GetUnregisteredPubStakeKeysCard = ({api, onRawResponse, onResponse, o
     api?.cip95
       .getUnregisteredPubStakeKeys()
       .then((unregPubStakeKeys) => {
-        console.log('unregPubStakeKeys: ', unregPubStakeKeys)
+        logger.log('unregPubStakeKeys: ', unregPubStakeKeys)
         onWaiting(false)
         onRawResponse(unregPubStakeKeys)
         if (unregPubStakeKeys.length < 1) {
@@ -23,7 +24,7 @@ const Cip95GetUnregisteredPubStakeKeysCard = ({api, onRawResponse, onResponse, o
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.log(e)
+        logger.log(e)
       })
   }
 

--- a/src/components/cards/cip95getUnregisteredPubStakeKeysCard.js
+++ b/src/components/cards/cip95getUnregisteredPubStakeKeysCard.js
@@ -1,17 +1,21 @@
 import React from 'react'
 import ApiCard from './apiCard'
-import { getPublicKeyFromHex } from '../../utils/cslTools'
+import {getPublicKeyFromHex} from '../../utils/cslTools'
 import runApiCall from '../../utils/runApiCall'
 
 const Cip95GetUnregisteredPubStakeKeysCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   const getUnregisteredPubStakeKeysClick = () =>
-    runApiCall(() => api.cip95.getUnregisteredPubStakeKeys(), {onRawResponse, onResponse, onWaiting}, {
-      parse: (unregPubStakeKeys) =>
-        unregPubStakeKeys.length < 1
-          ? 'No Unregistered Pub Stake Keys'
-          : getPublicKeyFromHex(unregPubStakeKeys[0]).hash().to_hex(),
-      stringify: false,
-    })
+    runApiCall(
+      () => api.cip95.getUnregisteredPubStakeKeys(),
+      {onRawResponse, onResponse, onWaiting},
+      {
+        parse: (unregPubStakeKeys) =>
+          unregPubStakeKeys.length < 1
+            ? 'No Unregistered Pub Stake Keys'
+            : getPublicKeyFromHex(unregPubStakeKeys[0]).hash().to_hex(),
+        stringify: false,
+      },
+    )
 
   const apiProps = {
     apiName: 'getUnregisteredPubStakeKeys',

--- a/src/components/cards/cip95getUnregisteredPubStakeKeysCard.js
+++ b/src/components/cards/cip95getUnregisteredPubStakeKeysCard.js
@@ -1,32 +1,17 @@
-import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 import { getPublicKeyFromHex } from '../../utils/cslTools'
+import runApiCall from '../../utils/runApiCall'
 
 const Cip95GetUnregisteredPubStakeKeysCard = ({api, onRawResponse, onResponse, onWaiting}) => {
-  const getUnregisteredPubStakeKeysClick = () => {
-    onWaiting(true)
-    api?.cip95
-      .getUnregisteredPubStakeKeys()
-      .then((unregPubStakeKeys) => {
-        logger.log('unregPubStakeKeys: ', unregPubStakeKeys)
-        onWaiting(false)
-        onRawResponse(unregPubStakeKeys)
-        if (unregPubStakeKeys.length < 1) {
-          onResponse('No Unregistered Pub Stake Keys', false)
-        } else {
-          const unregPubStakeKey = unregPubStakeKeys[0]
-          const stakeKeyHash = getPublicKeyFromHex(unregPubStakeKey).hash().to_hex()
-          onResponse(stakeKeyHash, false)
-        }
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.log(e)
-      })
-  }
+  const getUnregisteredPubStakeKeysClick = () =>
+    runApiCall(() => api.cip95.getUnregisteredPubStakeKeys(), {onRawResponse, onResponse, onWaiting}, {
+      parse: (unregPubStakeKeys) =>
+        unregPubStakeKeys.length < 1
+          ? 'No Unregistered Pub Stake Keys'
+          : getPublicKeyFromHex(unregPubStakeKeys[0]).hash().to_hex(),
+      stringify: false,
+    })
 
   const apiProps = {
     apiName: 'getUnregisteredPubStakeKeys',

--- a/src/components/cards/createRandomKeyCard.js
+++ b/src/components/cards/createRandomKeyCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 import { getAddressFromCred, getCredential, getSecretKey } from '../../utils/cslTools'
@@ -24,7 +25,7 @@ const CreateRandomKeyPart = ({onRawResponse, onResponse, onWaiting}) => {
     } catch(e) {
       onRawResponse('');
       onResponse(e);
-      console.error(e);
+      logger.error(e);
     } finally {
       onWaiting(false);
     }

--- a/src/components/cards/createRandomKeyCard.js
+++ b/src/components/cards/createRandomKeyCard.js
@@ -1,35 +1,28 @@
-import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 import { getAddressFromCred, getCredential, getSecretKey } from '../../utils/cslTools'
+import runApiCall from '../../utils/runApiCall'
 
 const CreateRandomKeyPart = ({onRawResponse, onResponse, onWaiting}) => {
 
-  const clickFunction = () => {
-    onWaiting(true)
-    try {
-      const wasmSK = getSecretKey()
-      const wasmPK = wasmSK.to_public();
-      const hash = wasmPK.to_raw_key().hash();
-      const cred = getCredential(hash);
-      const mainnetAddress = getAddressFromCred(1, cred)
-      const testnetAddress = getAddressFromCred(0, cred)
-      onRawResponse('');
-      onResponse({
-        privateKeyHex: wasmSK.to_raw_key().to_hex(),
-        publicKeyHex: wasmPK.to_raw_key().to_hex(),
-        pubKeyHash: hash.to_hex(),
-        mainnetAddress,
-        testnetAddress,
-      });
-    } catch(e) {
-      onRawResponse('');
-      onResponse(e);
-      logger.error(e);
-    } finally {
-      onWaiting(false);
-    }
-  }
+  const clickFunction = () =>
+    runApiCall(
+      async () => {
+        const wasmSK = getSecretKey()
+        const wasmPK = wasmSK.to_public()
+        const hash = wasmPK.to_raw_key().hash()
+        const cred = getCredential(hash)
+        return {
+          privateKeyHex: wasmSK.to_raw_key().to_hex(),
+          publicKeyHex: wasmPK.to_raw_key().to_hex(),
+          pubKeyHash: hash.to_hex(),
+          mainnetAddress: getAddressFromCred(1, cred),
+          testnetAddress: getAddressFromCred(0, cred),
+        }
+      },
+      {onRawResponse, onResponse, onWaiting},
+      {rawText: () => ''},
+    )
 
   return <ApiCard
     apiName="Random Key"

--- a/src/components/cards/createRandomKeyCard.js
+++ b/src/components/cards/createRandomKeyCard.js
@@ -1,10 +1,9 @@
 import React from 'react'
 import ApiCard from './apiCard'
-import { getAddressFromCred, getCredential, getSecretKey } from '../../utils/cslTools'
+import {getAddressFromCred, getCredential, getSecretKey} from '../../utils/cslTools'
 import runApiCall from '../../utils/runApiCall'
 
 const CreateRandomKeyPart = ({onRawResponse, onResponse, onWaiting}) => {
-
   const clickFunction = () =>
     runApiCall(
       async () => {
@@ -24,10 +23,7 @@ const CreateRandomKeyPart = ({onRawResponse, onResponse, onWaiting}) => {
       {rawText: () => ''},
     )
 
-  return <ApiCard
-    apiName="Random Key"
-    clickFunction={clickFunction}
-  />
+  return <ApiCard apiName="Random Key" clickFunction={clickFunction} />
 }
 
 export default CreateRandomKeyPart

--- a/src/components/cards/ethereum/getAccountsCard.js
+++ b/src/components/cards/ethereum/getAccountsCard.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import React from 'react'
 import ApiCard from '../apiCard'
 
@@ -15,7 +16,7 @@ const GetAccountsCard = ({onRawResponse, onResponse, onWaiting}) => {
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.error(e)
+        logger.error(e)
       })
   }
 

--- a/src/components/cards/ethereum/getAccountsCard.js
+++ b/src/components/cards/ethereum/getAccountsCard.js
@@ -1,24 +1,12 @@
-import logger from '../../../utils/logger'
 import React from 'react'
 import ApiCard from '../apiCard'
+import runApiCall from '../../../utils/runApiCall'
 
 const GetAccountsCard = ({onRawResponse, onResponse, onWaiting}) => {
-  const getAccountsClick = () => {
-    onWaiting(true)
-    window.ethereum
-      .request({method: 'eth_accounts'})
-      .then((accounts) => {
-        onWaiting(false)
-        onRawResponse(JSON.stringify(accounts))
-        onResponse(accounts)
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.error(e)
-      })
-  }
+  const getAccountsClick = () =>
+    runApiCall(() => window.ethereum.request({method: 'eth_accounts'}), {onRawResponse, onResponse, onWaiting}, {
+      rawText: (accounts) => JSON.stringify(accounts),
+    })
 
   return <ApiCard apiName="eth_accounts" clickFunction={getAccountsClick} />
 }

--- a/src/components/cards/ethereum/getAccountsCard.js
+++ b/src/components/cards/ethereum/getAccountsCard.js
@@ -4,9 +4,13 @@ import runApiCall from '../../../utils/runApiCall'
 
 const GetAccountsCard = ({onRawResponse, onResponse, onWaiting}) => {
   const getAccountsClick = () =>
-    runApiCall(() => window.ethereum.request({method: 'eth_accounts'}), {onRawResponse, onResponse, onWaiting}, {
-      rawText: (accounts) => JSON.stringify(accounts),
-    })
+    runApiCall(
+      () => window.ethereum.request({method: 'eth_accounts'}),
+      {onRawResponse, onResponse, onWaiting},
+      {
+        rawText: (accounts) => JSON.stringify(accounts),
+      },
+    )
 
   return <ApiCard apiName="eth_accounts" clickFunction={getAccountsClick} />
 }

--- a/src/components/cards/ethereum/getChainIdCard.js
+++ b/src/components/cards/ethereum/getChainIdCard.js
@@ -4,9 +4,13 @@ import runApiCall from '../../../utils/runApiCall'
 
 const GetChainIdCard = ({onRawResponse, onResponse, onWaiting}) => {
   const getChainIdClick = () =>
-    runApiCall(() => window.ethereum.request({method: 'eth_chainId'}), {onRawResponse, onResponse, onWaiting}, {
-      parse: (chainId) => ({chainId, decimal: parseInt(chainId, 16)}),
-    })
+    runApiCall(
+      () => window.ethereum.request({method: 'eth_chainId'}),
+      {onRawResponse, onResponse, onWaiting},
+      {
+        parse: (chainId) => ({chainId, decimal: parseInt(chainId, 16)}),
+      },
+    )
 
   return <ApiCard apiName="eth_chainId" clickFunction={getChainIdClick} />
 }

--- a/src/components/cards/ethereum/getChainIdCard.js
+++ b/src/components/cards/ethereum/getChainIdCard.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import React from 'react'
 import ApiCard from '../apiCard'
 
@@ -15,7 +16,7 @@ const GetChainIdCard = ({onRawResponse, onResponse, onWaiting}) => {
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.error(e)
+        logger.error(e)
       })
   }
 

--- a/src/components/cards/ethereum/getChainIdCard.js
+++ b/src/components/cards/ethereum/getChainIdCard.js
@@ -1,24 +1,12 @@
-import logger from '../../../utils/logger'
 import React from 'react'
 import ApiCard from '../apiCard'
+import runApiCall from '../../../utils/runApiCall'
 
 const GetChainIdCard = ({onRawResponse, onResponse, onWaiting}) => {
-  const getChainIdClick = () => {
-    onWaiting(true)
-    window.ethereum
-      .request({method: 'eth_chainId'})
-      .then((chainId) => {
-        onWaiting(false)
-        onRawResponse(chainId)
-        onResponse({chainId, decimal: parseInt(chainId, 16)})
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.error(e)
-      })
-  }
+  const getChainIdClick = () =>
+    runApiCall(() => window.ethereum.request({method: 'eth_chainId'}), {onRawResponse, onResponse, onWaiting}, {
+      parse: (chainId) => ({chainId, decimal: parseInt(chainId, 16)}),
+    })
 
   return <ApiCard apiName="eth_chainId" clickFunction={getChainIdClick} />
 }

--- a/src/components/cards/ethereum/getErc20BalanceCard.js
+++ b/src/components/cards/ethereum/getErc20BalanceCard.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 /* global BigInt */
 import React, {useState} from 'react'
 import ApiCardWithModal from '../apiCardWithModal'
@@ -33,7 +34,7 @@ const GetErc20BalanceCard = ({accounts, onRawResponse, onResponse, onWaiting}) =
     } catch (e) {
       onRawResponse('')
       onResponse(e)
-      console.error(e)
+      logger.error(e)
     } finally {
       onWaiting(false)
     }

--- a/src/components/cards/ethereum/getErc20BalanceCard.js
+++ b/src/components/cards/ethereum/getErc20BalanceCard.js
@@ -1,7 +1,8 @@
 /* global BigInt */
 import React, {useState} from 'react'
 import ApiCardWithModal from '../apiCardWithModal'
-import {ModalWindowContent, CommonStyles} from '../../ui-constants'
+import {ModalWindowContent} from '../../ui-constants'
+import InputWithLabel from '../../inputWithLabel'
 import {balanceOfData} from '../../../utils/ethereumUtils'
 import runApiCall from '../../../utils/runApiCall'
 
@@ -32,32 +33,20 @@ const GetErc20BalanceCard = ({accounts, onRawResponse, onResponse, onWaiting}) =
   return (
     <ApiCardWithModal buttonLabel="ERC-20 balanceOf" clickFunction={getBalanceClick} btnDisabled={!isValid}>
       <div className={ModalWindowContent.contentPadding}>
-        <div className="mb-3">
-          <label htmlFor="erc20Contract" className={ModalWindowContent.contentLabelStyle}>
-            Token Contract Address (0x...)
-          </label>
-          <input
-            type="text"
-            id="erc20Contract"
-            className={CommonStyles.inputStyles}
-            placeholder="0xTokenContractAddress"
-            value={contractAddress}
-            onChange={(e) => setContractAddress(e.target.value)}
-          />
-        </div>
-        <div>
-          <label htmlFor="erc20Holder" className={ModalWindowContent.contentLabelStyle}>
-            Holder Address (optional, defaults to connected account)
-          </label>
-          <input
-            type="text"
-            id="erc20Holder"
-            className={CommonStyles.inputStyles}
-            placeholder="0xHolderAddress (optional)"
-            value={holderAddress}
-            onChange={(e) => setHolderAddress(e.target.value)}
-          />
-        </div>
+        <InputWithLabel
+          inputName="Token Contract Address (0x...)"
+          inputValue={contractAddress}
+          onChangeFunction={(e) => setContractAddress(e.target.value)}
+          placeholder="0xTokenContractAddress"
+          wrapperClassName="mb-3"
+        />
+        <InputWithLabel
+          inputName="Holder Address (optional, defaults to connected account)"
+          inputValue={holderAddress}
+          onChangeFunction={(e) => setHolderAddress(e.target.value)}
+          placeholder="0xHolderAddress (optional)"
+          wrapperClassName=""
+        />
       </div>
     </ApiCardWithModal>
   )

--- a/src/components/cards/ethereum/getErc20BalanceCard.js
+++ b/src/components/cards/ethereum/getErc20BalanceCard.js
@@ -1,43 +1,30 @@
-import logger from '../../../utils/logger'
 /* global BigInt */
 import React, {useState} from 'react'
 import ApiCardWithModal from '../apiCardWithModal'
 import {ModalWindowContent, CommonStyles} from '../../ui-constants'
 import {balanceOfData} from '../../../utils/ethereumUtils'
+import runApiCall from '../../../utils/runApiCall'
 
 const GetErc20BalanceCard = ({accounts, onRawResponse, onResponse, onWaiting}) => {
   const [contractAddress, setContractAddress] = useState('')
   const [holderAddress, setHolderAddress] = useState('')
 
-  const getBalanceClick = async () => {
+  const getBalanceClick = () => {
     const holder = holderAddress || (accounts && accounts[0])
     if (!holder) {
       onResponse('No address to check')
       return
     }
-    onWaiting(true)
-    try {
-      const result = await window.ethereum.request({
-        method: 'eth_call',
-        params: [
-          {
-            to: contractAddress,
-            data: balanceOfData(holder),
-          },
-          'latest',
-        ],
-      })
-      onRawResponse(result)
-      // result is a 32-byte hex: parse as BigInt
-      const balance = BigInt(result)
-      onResponse({contract: contractAddress, holder, rawHex: result, balance: balance.toString()})
-    } catch (e) {
-      onRawResponse('')
-      onResponse(e)
-      logger.error(e)
-    } finally {
-      onWaiting(false)
-    }
+    return runApiCall(
+      () =>
+        window.ethereum.request({
+          method: 'eth_call',
+          params: [{to: contractAddress, data: balanceOfData(holder)}, 'latest'],
+        }),
+      {onRawResponse, onResponse, onWaiting},
+      // result is a 32-byte hex; parse as BigInt
+      {parse: (result) => ({contract: contractAddress, holder, rawHex: result, balance: BigInt(result).toString()})},
+    )
   }
 
   const isValid = contractAddress.startsWith('0x') && contractAddress.length === 42

--- a/src/components/cards/ethereum/getEthBalanceCard.js
+++ b/src/components/cards/ethereum/getEthBalanceCard.js
@@ -1,7 +1,7 @@
-import logger from '../../../utils/logger'
 import React from 'react'
 import ApiCard from '../apiCard'
 import {weiHexToEth} from '../../../utils/ethereumUtils'
+import runApiCall from '../../../utils/runApiCall'
 
 const GetEthBalanceCard = ({accounts, onRawResponse, onResponse, onWaiting}) => {
   const getBalanceClick = () => {
@@ -9,20 +9,11 @@ const GetEthBalanceCard = ({accounts, onRawResponse, onResponse, onWaiting}) => 
       onResponse('No account connected')
       return
     }
-    onWaiting(true)
-    window.ethereum
-      .request({method: 'eth_getBalance', params: [accounts[0], 'latest']})
-      .then((hexBalance) => {
-        onWaiting(false)
-        onRawResponse(hexBalance)
-        onResponse({account: accounts[0], balanceWei: hexBalance, balanceEth: weiHexToEth(hexBalance)})
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.error(e)
-      })
+    return runApiCall(
+      () => window.ethereum.request({method: 'eth_getBalance', params: [accounts[0], 'latest']}),
+      {onRawResponse, onResponse, onWaiting},
+      {parse: (hexBalance) => ({account: accounts[0], balanceWei: hexBalance, balanceEth: weiHexToEth(hexBalance)})},
+    )
   }
 
   return <ApiCard apiName="eth_getBalance" clickFunction={getBalanceClick} />

--- a/src/components/cards/ethereum/getEthBalanceCard.js
+++ b/src/components/cards/ethereum/getEthBalanceCard.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import React from 'react'
 import ApiCard from '../apiCard'
 import {weiHexToEth} from '../../../utils/ethereumUtils'
@@ -20,7 +21,7 @@ const GetEthBalanceCard = ({accounts, onRawResponse, onResponse, onWaiting}) => 
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.error(e)
+        logger.error(e)
       })
   }
 

--- a/src/components/cards/ethereum/sendEthTransactionCard.js
+++ b/src/components/cards/ethereum/sendEthTransactionCard.js
@@ -1,6 +1,7 @@
 import React, {useState} from 'react'
 import ApiCardWithModal from '../apiCardWithModal'
-import {ModalWindowContent, CommonStyles} from '../../ui-constants'
+import {ModalWindowContent} from '../../ui-constants'
+import InputWithLabel from '../../inputWithLabel'
 import {ethToHexWei} from '../../../utils/ethereumUtils'
 import runApiCall from '../../../utils/runApiCall'
 
@@ -29,34 +30,23 @@ const SendEthTransactionCard = ({accounts, onRawResponse, onResponse, onWaiting}
   return (
     <ApiCardWithModal buttonLabel="eth_sendTransaction" clickFunction={sendTxClick} btnDisabled={!isValid}>
       <div className={ModalWindowContent.contentPadding}>
-        <div className="mb-3">
-          <label htmlFor="ethToAddress" className={ModalWindowContent.contentLabelStyle}>
-            To Address (0x...)
-          </label>
-          <input
-            type="text"
-            id="ethToAddress"
-            className={CommonStyles.inputStyles}
-            placeholder="0xRecipientAddress"
-            value={toAddress}
-            onChange={(e) => setToAddress(e.target.value)}
-          />
-        </div>
-        <div>
-          <label htmlFor="ethAmount" className={ModalWindowContent.contentLabelStyle}>
-            Amount (ETH)
-          </label>
-          <input
-            type="number"
-            id="ethAmount"
-            className={CommonStyles.inputStyles}
-            placeholder="0.001"
-            step="0.001"
-            min="0"
-            value={amount}
-            onChange={(e) => setAmount(e.target.value)}
-          />
-        </div>
+        <InputWithLabel
+          inputName="To Address (0x...)"
+          inputValue={toAddress}
+          onChangeFunction={(e) => setToAddress(e.target.value)}
+          placeholder="0xRecipientAddress"
+          wrapperClassName="mb-3"
+        />
+        <InputWithLabel
+          inputName="Amount (ETH)"
+          type="number"
+          min="0"
+          step="0.001"
+          inputValue={amount}
+          onChangeFunction={(e) => setAmount(e.target.value)}
+          placeholder="0.001"
+          wrapperClassName=""
+        />
       </div>
     </ApiCardWithModal>
   )

--- a/src/components/cards/ethereum/sendEthTransactionCard.js
+++ b/src/components/cards/ethereum/sendEthTransactionCard.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import React, {useState} from 'react'
 import ApiCardWithModal from '../apiCardWithModal'
 import {ModalWindowContent, CommonStyles} from '../../ui-constants'
@@ -29,7 +30,7 @@ const SendEthTransactionCard = ({accounts, onRawResponse, onResponse, onWaiting}
     } catch (e) {
       onRawResponse('')
       onResponse(e)
-      console.error(e)
+      logger.error(e)
     } finally {
       onWaiting(false)
     }

--- a/src/components/cards/ethereum/sendEthTransactionCard.js
+++ b/src/components/cards/ethereum/sendEthTransactionCard.js
@@ -1,39 +1,27 @@
-import logger from '../../../utils/logger'
 import React, {useState} from 'react'
 import ApiCardWithModal from '../apiCardWithModal'
 import {ModalWindowContent, CommonStyles} from '../../ui-constants'
 import {ethToHexWei} from '../../../utils/ethereumUtils'
+import runApiCall from '../../../utils/runApiCall'
 
 const SendEthTransactionCard = ({accounts, onRawResponse, onResponse, onWaiting}) => {
   const [toAddress, setToAddress] = useState('')
   const [amount, setAmount] = useState('')
 
-  const sendTxClick = async () => {
+  const sendTxClick = () => {
     if (!accounts || accounts.length === 0) {
       onResponse('No account connected')
       return
     }
-    onWaiting(true)
-    try {
-      const txHash = await window.ethereum.request({
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            from: accounts[0],
-            to: toAddress,
-            value: ethToHexWei(amount),
-          },
-        ],
-      })
-      onRawResponse(txHash)
-      onResponse({txHash, from: accounts[0], to: toAddress, amountEth: amount})
-    } catch (e) {
-      onRawResponse('')
-      onResponse(e)
-      logger.error(e)
-    } finally {
-      onWaiting(false)
-    }
+    return runApiCall(
+      () =>
+        window.ethereum.request({
+          method: 'eth_sendTransaction',
+          params: [{from: accounts[0], to: toAddress, value: ethToHexWei(amount)}],
+        }),
+      {onRawResponse, onResponse, onWaiting},
+      {parse: (txHash) => ({txHash, from: accounts[0], to: toAddress, amountEth: amount})},
+    )
   }
 
   const isValid = toAddress.startsWith('0x') && toAddress.length === 42 && amount && parseFloat(amount) > 0

--- a/src/components/cards/ethereum/signEthMessageCard.js
+++ b/src/components/cards/ethereum/signEthMessageCard.js
@@ -1,6 +1,7 @@
 import React, {useState} from 'react'
 import ApiCardWithModal from '../apiCardWithModal'
-import {ModalWindowContent, CommonStyles} from '../../ui-constants'
+import {ModalWindowContent} from '../../ui-constants'
+import InputWithLabel from '../../inputWithLabel'
 import runApiCall from '../../../utils/runApiCall'
 
 const SignEthMessageCard = ({accounts, onRawResponse, onResponse, onWaiting}) => {
@@ -21,16 +22,12 @@ const SignEthMessageCard = ({accounts, onRawResponse, onResponse, onWaiting}) =>
   return (
     <ApiCardWithModal buttonLabel="personal_sign" clickFunction={signMessageClick} btnDisabled={!message}>
       <div className={ModalWindowContent.contentPadding}>
-        <label htmlFor="ethSignMessage" className={ModalWindowContent.contentLabelStyle}>
-          Message to sign
-        </label>
-        <input
-          type="text"
-          id="ethSignMessage"
-          className={CommonStyles.inputStyles}
+        <InputWithLabel
+          inputName="Message to sign"
+          inputValue={message}
+          onChangeFunction={(e) => setMessage(e.target.value)}
           placeholder="Hello, Ethereum!"
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
+          wrapperClassName=""
         />
       </div>
     </ApiCardWithModal>

--- a/src/components/cards/ethereum/signEthMessageCard.js
+++ b/src/components/cards/ethereum/signEthMessageCard.js
@@ -1,31 +1,21 @@
-import logger from '../../../utils/logger'
 import React, {useState} from 'react'
 import ApiCardWithModal from '../apiCardWithModal'
 import {ModalWindowContent, CommonStyles} from '../../ui-constants'
+import runApiCall from '../../../utils/runApiCall'
 
 const SignEthMessageCard = ({accounts, onRawResponse, onResponse, onWaiting}) => {
   const [message, setMessage] = useState('')
 
-  const signMessageClick = async () => {
+  const signMessageClick = () => {
     if (!accounts || accounts.length === 0) {
       onResponse('No account connected')
       return
     }
-    onWaiting(true)
-    try {
-      const signature = await window.ethereum.request({
-        method: 'personal_sign',
-        params: [message, accounts[0]],
-      })
-      onRawResponse(signature)
-      onResponse({account: accounts[0], message, signature})
-    } catch (e) {
-      onRawResponse('')
-      onResponse(e)
-      logger.error(e)
-    } finally {
-      onWaiting(false)
-    }
+    return runApiCall(
+      () => window.ethereum.request({method: 'personal_sign', params: [message, accounts[0]]}),
+      {onRawResponse, onResponse, onWaiting},
+      {parse: (signature) => ({account: accounts[0], message, signature})},
+    )
   }
 
   return (

--- a/src/components/cards/ethereum/signEthMessageCard.js
+++ b/src/components/cards/ethereum/signEthMessageCard.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import React, {useState} from 'react'
 import ApiCardWithModal from '../apiCardWithModal'
 import {ModalWindowContent, CommonStyles} from '../../ui-constants'
@@ -21,7 +22,7 @@ const SignEthMessageCard = ({accounts, onRawResponse, onResponse, onWaiting}) =>
     } catch (e) {
       onRawResponse('')
       onResponse(e)
-      console.error(e)
+      logger.error(e)
     } finally {
       onWaiting(false)
     }

--- a/src/components/cards/ethereum/transferErc20Card.js
+++ b/src/components/cards/ethereum/transferErc20Card.js
@@ -1,7 +1,8 @@
 /* global BigInt */
 import React, {useState} from 'react'
 import ApiCardWithModal from '../apiCardWithModal'
-import {ModalWindowContent, CommonStyles} from '../../ui-constants'
+import {ModalWindowContent} from '../../ui-constants'
+import InputWithLabel from '../../inputWithLabel'
 import {transferData} from '../../../utils/ethereumUtils'
 import runApiCall from '../../../utils/runApiCall'
 
@@ -37,45 +38,27 @@ const TransferErc20Card = ({accounts, onRawResponse, onResponse, onWaiting}) => 
   return (
     <ApiCardWithModal buttonLabel="ERC-20 transfer" clickFunction={transferClick} btnDisabled={!isValid}>
       <div className={ModalWindowContent.contentPadding}>
-        <div className="mb-3">
-          <label htmlFor="transferContract" className={ModalWindowContent.contentLabelStyle}>
-            Token Contract Address (0x...)
-          </label>
-          <input
-            type="text"
-            id="transferContract"
-            className={CommonStyles.inputStyles}
-            placeholder="0xTokenContractAddress"
-            value={contractAddress}
-            onChange={(e) => setContractAddress(e.target.value)}
-          />
-        </div>
-        <div className="mb-3">
-          <label htmlFor="transferTo" className={ModalWindowContent.contentLabelStyle}>
-            Recipient Address (0x...)
-          </label>
-          <input
-            type="text"
-            id="transferTo"
-            className={CommonStyles.inputStyles}
-            placeholder="0xRecipientAddress"
-            value={toAddress}
-            onChange={(e) => setToAddress(e.target.value)}
-          />
-        </div>
-        <div>
-          <label htmlFor="transferAmount" className={ModalWindowContent.contentLabelStyle}>
-            Amount (in token's smallest unit, e.g. wei for 18-decimal tokens)
-          </label>
-          <input
-            type="text"
-            id="transferAmount"
-            className={CommonStyles.inputStyles}
-            placeholder="1000000000000000000"
-            value={amount}
-            onChange={(e) => setAmount(e.target.value)}
-          />
-        </div>
+        <InputWithLabel
+          inputName="Token Contract Address (0x...)"
+          inputValue={contractAddress}
+          onChangeFunction={(e) => setContractAddress(e.target.value)}
+          placeholder="0xTokenContractAddress"
+          wrapperClassName="mb-3"
+        />
+        <InputWithLabel
+          inputName="Recipient Address (0x...)"
+          inputValue={toAddress}
+          onChangeFunction={(e) => setToAddress(e.target.value)}
+          placeholder="0xRecipientAddress"
+          wrapperClassName="mb-3"
+        />
+        <InputWithLabel
+          inputName="Amount (in token's smallest unit, e.g. wei for 18-decimal tokens)"
+          inputValue={amount}
+          onChangeFunction={(e) => setAmount(e.target.value)}
+          placeholder="1000000000000000000"
+          wrapperClassName=""
+        />
       </div>
     </ApiCardWithModal>
   )

--- a/src/components/cards/ethereum/transferErc20Card.js
+++ b/src/components/cards/ethereum/transferErc20Card.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 /* global BigInt */
 import React, {useState} from 'react'
 import ApiCardWithModal from '../apiCardWithModal'
@@ -32,7 +33,7 @@ const TransferErc20Card = ({accounts, onRawResponse, onResponse, onWaiting}) => 
     } catch (e) {
       onRawResponse('')
       onResponse(e)
-      console.error(e)
+      logger.error(e)
     } finally {
       onWaiting(false)
     }

--- a/src/components/cards/ethereum/transferErc20Card.js
+++ b/src/components/cards/ethereum/transferErc20Card.js
@@ -1,42 +1,29 @@
-import logger from '../../../utils/logger'
 /* global BigInt */
 import React, {useState} from 'react'
 import ApiCardWithModal from '../apiCardWithModal'
 import {ModalWindowContent, CommonStyles} from '../../ui-constants'
 import {transferData} from '../../../utils/ethereumUtils'
+import runApiCall from '../../../utils/runApiCall'
 
 const TransferErc20Card = ({accounts, onRawResponse, onResponse, onWaiting}) => {
   const [contractAddress, setContractAddress] = useState('')
   const [toAddress, setToAddress] = useState('')
   const [amount, setAmount] = useState('')
 
-  const transferClick = async () => {
+  const transferClick = () => {
     if (!accounts || accounts.length === 0) {
       onResponse('No account connected')
       return
     }
-    onWaiting(true)
-    try {
-      const amountWei = BigInt(amount).toString()
-      const txHash = await window.ethereum.request({
-        method: 'eth_sendTransaction',
-        params: [
-          {
-            from: accounts[0],
-            to: contractAddress,
-            data: transferData(toAddress, amountWei),
-          },
-        ],
-      })
-      onRawResponse(txHash)
-      onResponse({txHash, contract: contractAddress, from: accounts[0], to: toAddress, amount})
-    } catch (e) {
-      onRawResponse('')
-      onResponse(e)
-      logger.error(e)
-    } finally {
-      onWaiting(false)
-    }
+    return runApiCall(
+      () =>
+        window.ethereum.request({
+          method: 'eth_sendTransaction',
+          params: [{from: accounts[0], to: contractAddress, data: transferData(toAddress, BigInt(amount).toString())}],
+        }),
+      {onRawResponse, onResponse, onWaiting},
+      {parse: (txHash) => ({txHash, contract: contractAddress, from: accounts[0], to: toAddress, amount})},
+    )
   }
 
   const isValid =

--- a/src/components/cards/getAllInfoCard.js
+++ b/src/components/cards/getAllInfoCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 import {
@@ -30,102 +31,102 @@ const GetAllInfoCard = ({api, onWaiting, onError, setters}) => {
     onWaiting(true)
     getBalance(api)
       .then((adaValue) => {
-        console.log('[dApp][GetAllInfoCard][getBalance]: ', adaValue)
+        logger.log('[dApp][GetAllInfoCard][getBalance]: ', adaValue)
         setBalance(adaValue)
       })
       .catch((e) => {
-        console.error(e)
+        logger.error(e)
         onWaiting(false)
         onError()
       })
 
     getUTxOs(api)
       .then((utxos) => {
-        console.log('[dApp][GetAllInfoCard][getUTxOs]: ', utxos)
+        logger.log('[dApp][GetAllInfoCard][getUTxOs]: ', utxos)
         setAndMapUtxos(utxos)
       })
       .catch((e) => {
-        console.error(e)
+        logger.error(e)
         onWaiting(false)
         onError()
       })
 
     getChangeAddress(api)
       .then((bech32Addr) => {
-        console.log('[dApp][GetAllInfoCard][getChangeAddress]: ', bech32Addr)
+        logger.log('[dApp][GetAllInfoCard][getChangeAddress]: ', bech32Addr)
         setChangeAddress(bech32Addr)
       })
       .catch((e) => {
-        console.error(e)
+        logger.error(e)
         onWaiting(false)
         onError()
       })
 
     getRewardAddress(api)
       .then((bech32Addr) => {
-        console.log('[dApp][GetAllInfoCard][getRewardAddress]: ', bech32Addr)
+        logger.log('[dApp][GetAllInfoCard][getRewardAddress]: ', bech32Addr)
         setRewardAddress(bech32Addr)
       })
       .catch((e) => {
-        console.error(e)
+        logger.error(e)
         onWaiting(false)
         onError()
       })
 
     getUsedAddress(api)
       .then((bech32Addr) => {
-        console.log('[dApp][GetAllInfoCard][getUsedAddress]: ', bech32Addr)
+        logger.log('[dApp][GetAllInfoCard][getUsedAddress]: ', bech32Addr)
         setUsedAddress(bech32Addr)
       })
       .catch((e) => {
-        console.error(e)
+        logger.error(e)
         onWaiting(false)
         onError()
       })
 
     getUnusedAddress(api)
       .then((bech32Addr) => {
-        console.log('[dApp][GetAllInfoCard][getUnusedAddress]: ', bech32Addr)
+        logger.log('[dApp][GetAllInfoCard][getUnusedAddress]: ', bech32Addr)
         setUnusedAddress(bech32Addr)
       })
       .catch((e) => {
-        console.error(e)
+        logger.error(e)
         onWaiting(false)
         onError()
       })
 
     getPubDRepKey(api)
       .then((drepKey) => {
-        console.log('[dApp][GetAllInfoCard][getPubDRepKey]: ', drepKey)
+        logger.log('[dApp][GetAllInfoCard][getPubDRepKey]: ', drepKey)
         setDRepIdBech32(drepKey.dRepIDBech32)
         setDRepIdHex(drepKey.dRepIDHex)
         setDRepIdInputValue(drepKey.dRepIDBech32)
       })
       .catch((e) => {
-        console.error(e)
+        logger.error(e)
         onWaiting(false)
         onError()
       })
 
     getRegPubStakeKey(api)
       .then((stakeKeyHash) => {
-        console.log('[dApp][GetAllInfoCard][getRegPubStakeKey]: ', stakeKeyHash)
+        logger.log('[dApp][GetAllInfoCard][getRegPubStakeKey]: ', stakeKeyHash)
         setRegPubStakeKey(stakeKeyHash)
       })
       .catch((e) => {
-        console.error(e)
+        logger.error(e)
         onWaiting(false)
         onError()
       })
 
     getUnregPubStakeKey(api)
       .then((stakeKeyHash) => {
-        console.log('[dApp][GetAllInfoCard][getUnregPubStakeKey]: ', stakeKeyHash)
+        logger.log('[dApp][GetAllInfoCard][getUnregPubStakeKey]: ', stakeKeyHash)
         setUnregPubStakeKey(stakeKeyHash)
         onWaiting(false)
       })
       .catch((e) => {
-        console.error(e)
+        logger.error(e)
         onWaiting(false)
         onError()
       })

--- a/src/components/cards/getBalanceCard.js
+++ b/src/components/cards/getBalanceCard.js
@@ -6,15 +6,19 @@ import runApiCall from '../../utils/runApiCall'
 
 const GetBalanceCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   const getBalanceClick = () =>
-    runApiCall(() => api.getBalance(), {onRawResponse, onResponse, onWaiting}, {
-      parse: (hexBalance) => {
-        const cslValue = getCslValue(hexBalance)
-        return {
-          lovelaces: cslValue.coin().to_str(),
-          assets: wasmMultiassetToJSONs(cslValue.multiasset()),
-        }
+    runApiCall(
+      () => api.getBalance(),
+      {onRawResponse, onResponse, onWaiting},
+      {
+        parse: (hexBalance) => {
+          const cslValue = getCslValue(hexBalance)
+          return {
+            lovelaces: cslValue.coin().to_str(),
+            assets: wasmMultiassetToJSONs(cslValue.multiasset()),
+          }
+        },
       },
-    })
+    )
 
   const apiProps = {
     apiName: 'getBalance',

--- a/src/components/cards/getBalanceCard.js
+++ b/src/components/cards/getBalanceCard.js
@@ -1,29 +1,20 @@
-import logger from '../../utils/logger'
 import React from 'react'
 import {wasmMultiassetToJSONs} from '../../utils/utils'
 import ApiCard from './apiCard'
 import {getCslValue} from '../../utils/cslTools'
+import runApiCall from '../../utils/runApiCall'
 
 const GetBalanceCard = ({api, onRawResponse, onResponse, onWaiting}) => {
-  const getBalanceClick = () => {
-    onWaiting(true)
-    api
-      ?.getBalance()
-      .then((hexBalance) => {
-        onWaiting(false)
-        onRawResponse(hexBalance)
+  const getBalanceClick = () =>
+    runApiCall(() => api.getBalance(), {onRawResponse, onResponse, onWaiting}, {
+      parse: (hexBalance) => {
         const cslValue = getCslValue(hexBalance)
-        const adaValue = cslValue.coin().to_str()
-        const assetValue = wasmMultiassetToJSONs(cslValue.multiasset())
-        onResponse({lovelaces: adaValue, assets: assetValue})
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.log(e)
-      })
-  }
+        return {
+          lovelaces: cslValue.coin().to_str(),
+          assets: wasmMultiassetToJSONs(cslValue.multiasset()),
+        }
+      },
+    })
 
   const apiProps = {
     apiName: 'getBalance',

--- a/src/components/cards/getBalanceCard.js
+++ b/src/components/cards/getBalanceCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React from 'react'
 import {wasmMultiassetToJSONs} from '../../utils/utils'
 import ApiCard from './apiCard'
@@ -20,7 +21,7 @@ const GetBalanceCard = ({api, onRawResponse, onResponse, onWaiting}) => {
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.log(e)
+        logger.log(e)
       })
   }
 

--- a/src/components/cards/getChangeAddressCard.js
+++ b/src/components/cards/getChangeAddressCard.js
@@ -5,10 +5,14 @@ import runApiCall from '../../utils/runApiCall'
 
 const GetChangeAddressCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   const getChangeAddressClick = () =>
-    runApiCall(() => api.getChangeAddress(), {onRawResponse, onResponse, onWaiting}, {
-      parse: getBech32AddressFromHex,
-      stringify: false,
-    })
+    runApiCall(
+      () => api.getChangeAddress(),
+      {onRawResponse, onResponse, onWaiting},
+      {
+        parse: getBech32AddressFromHex,
+        stringify: false,
+      },
+    )
 
   const apiProps = {
     apiName: 'getChangeAddress',

--- a/src/components/cards/getChangeAddressCard.js
+++ b/src/components/cards/getChangeAddressCard.js
@@ -1,25 +1,14 @@
-import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 import {getBech32AddressFromHex} from '../../utils/cslTools'
+import runApiCall from '../../utils/runApiCall'
 
 const GetChangeAddressCard = ({api, onRawResponse, onResponse, onWaiting}) => {
-  const getChangeAddressClick = () => {
-    onWaiting(true)
-    api
-      ?.getChangeAddress()
-      .then((hexAddress) => {
-        onWaiting(false)
-        onRawResponse(hexAddress)
-        onResponse(getBech32AddressFromHex(hexAddress), false)
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.log(e)
-      })
-  }
+  const getChangeAddressClick = () =>
+    runApiCall(() => api.getChangeAddress(), {onRawResponse, onResponse, onWaiting}, {
+      parse: getBech32AddressFromHex,
+      stringify: false,
+    })
 
   const apiProps = {
     apiName: 'getChangeAddress',

--- a/src/components/cards/getChangeAddressCard.js
+++ b/src/components/cards/getChangeAddressCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 import {getBech32AddressFromHex} from '../../utils/cslTools'
@@ -16,7 +17,7 @@ const GetChangeAddressCard = ({api, onRawResponse, onResponse, onWaiting}) => {
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.log(e)
+        logger.log(e)
       })
   }
 

--- a/src/components/cards/getCollateralUtxosCard.js
+++ b/src/components/cards/getCollateralUtxosCard.js
@@ -1,6 +1,7 @@
 import React, {useState} from 'react'
 import ApiCardWithModal from './apiCardWithModal'
-import {CommonStyles, ModalWindowContent} from '../ui-constants'
+import {ModalWindowContent} from '../ui-constants'
+import InputWithLabel from '../inputWithLabel'
 import {getAmountInHex, getUtxoFromHex} from '../../utils/cslTools'
 import runApiCall from '../../utils/runApiCall'
 
@@ -22,17 +23,14 @@ const GetCollateralUtxosCard = ({api, onRawResponse, onResponse, onWaiting}) => 
   return (
     <ApiCardWithModal {...apiProps}>
       <div className={ModalWindowContent.contentPadding}>
-        <label htmlFor="amount" className={ModalWindowContent.contentLabelStyle}>
-          Amount
-        </label>
-        <input
+        <InputWithLabel
+          inputName="Amount"
           type="number"
           min="0"
-          id="amount"
-          className={CommonStyles.inputStyles}
           placeholder="2000000"
-          value={getCollateralUtxosInput}
-          onChange={(event) => setGetCollateralUtxosInput(event.target.value)}
+          inputValue={getCollateralUtxosInput}
+          onChangeFunction={(event) => setGetCollateralUtxosInput(event.target.value)}
+          wrapperClassName=""
         />
       </div>
     </ApiCardWithModal>

--- a/src/components/cards/getCollateralUtxosCard.js
+++ b/src/components/cards/getCollateralUtxosCard.js
@@ -2,7 +2,7 @@ import React, {useState} from 'react'
 import ApiCardWithModal from './apiCardWithModal'
 import {ModalWindowContent} from '../ui-constants'
 import InputWithLabel from '../inputWithLabel'
-import {getAmountInHex, getUtxoFromHex} from '../../utils/cslTools'
+import {getAmountInHex, hexArrayToUtxos} from '../../utils/cslTools'
 import runApiCall from '../../utils/runApiCall'
 
 const GetCollateralUtxosCard = ({api, onRawResponse, onResponse, onWaiting}) => {
@@ -11,7 +11,7 @@ const GetCollateralUtxosCard = ({api, onRawResponse, onResponse, onWaiting}) => 
   const getCollateralUtxosClick = () => {
     const amountInHex = getCollateralUtxosInput ? getAmountInHex(getCollateralUtxosInput) : undefined
     return runApiCall(() => api.getCollateral(amountInHex), {onRawResponse, onResponse, onWaiting}, {
-      parse: (hexUtxos) => hexUtxos.map(getUtxoFromHex),
+      parse: hexArrayToUtxos,
     })
   }
 

--- a/src/components/cards/getCollateralUtxosCard.js
+++ b/src/components/cards/getCollateralUtxosCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React, {useState} from 'react'
 import ApiCardWithModal from './apiCardWithModal'
 import {CommonStyles, ModalWindowContent} from '../ui-constants'
@@ -25,7 +26,7 @@ const GetCollateralUtxosCard = ({api, onRawResponse, onResponse, onWaiting}) => 
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.log(e)
+        logger.log(e)
       })
   }
 

--- a/src/components/cards/getCollateralUtxosCard.js
+++ b/src/components/cards/getCollateralUtxosCard.js
@@ -10,9 +10,13 @@ const GetCollateralUtxosCard = ({api, onRawResponse, onResponse, onWaiting}) => 
 
   const getCollateralUtxosClick = () => {
     const amountInHex = getCollateralUtxosInput ? getAmountInHex(getCollateralUtxosInput) : undefined
-    return runApiCall(() => api.getCollateral(amountInHex), {onRawResponse, onResponse, onWaiting}, {
-      parse: hexArrayToUtxos,
-    })
+    return runApiCall(
+      () => api.getCollateral(amountInHex),
+      {onRawResponse, onResponse, onWaiting},
+      {
+        parse: hexArrayToUtxos,
+      },
+    )
   }
 
   const apiProps = {

--- a/src/components/cards/getCollateralUtxosCard.js
+++ b/src/components/cards/getCollateralUtxosCard.js
@@ -1,33 +1,17 @@
-import logger from '../../utils/logger'
 import React, {useState} from 'react'
 import ApiCardWithModal from './apiCardWithModal'
 import {CommonStyles, ModalWindowContent} from '../ui-constants'
 import {getAmountInHex, getUtxoFromHex} from '../../utils/cslTools'
+import runApiCall from '../../utils/runApiCall'
 
 const GetCollateralUtxosCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   const [getCollateralUtxosInput, setGetCollateralUtxosInput] = useState('2000000')
 
   const getCollateralUtxosClick = () => {
     const amountInHex = getCollateralUtxosInput ? getAmountInHex(getCollateralUtxosInput) : undefined
-    onWaiting(true)
-    api
-      ?.getCollateral(amountInHex)
-      .then((hexUtxos) => {
-        onWaiting(false)
-        onRawResponse(hexUtxos)
-        let utxos = []
-        for (const hexUtxo of hexUtxos) {
-          const utxo = getUtxoFromHex(hexUtxo)
-          utxos.push(utxo)
-        }
-        onResponse(utxos)
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.log(e)
-      })
+    return runApiCall(() => api.getCollateral(amountInHex), {onRawResponse, onResponse, onWaiting}, {
+      parse: (hexUtxos) => hexUtxos.map(getUtxoFromHex),
+    })
   }
 
   const apiProps = {

--- a/src/components/cards/getExtensionsCard.js
+++ b/src/components/cards/getExtensionsCard.js
@@ -1,23 +1,10 @@
-import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
+import runApiCall from '../../utils/runApiCall'
 
 const GetExtensionsCard = ({api, onRawResponse, onResponse, onWaiting}) => {
-  const getExtensionsClick = () => {
-    onWaiting(true)
-    api?.getExtensions()
-      .then((response) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(response)
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.log(e)
-      })
-  }
+  const getExtensionsClick = () =>
+    runApiCall(() => api.getExtensions(), {onRawResponse, onResponse, onWaiting}, {rawText: () => ''})
 
   const apiProps = {
     apiName: 'getExtensions',

--- a/src/components/cards/getExtensionsCard.js
+++ b/src/components/cards/getExtensionsCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 
@@ -14,7 +15,7 @@ const GetExtensionsCard = ({api, onRawResponse, onResponse, onWaiting}) => {
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.log(e)
+        logger.log(e)
       })
   }
 

--- a/src/components/cards/getNetworkIdCard.js
+++ b/src/components/cards/getNetworkIdCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 
@@ -15,7 +16,7 @@ const GetNetworkIdCard = ({api, onRawResponse, onResponse, onWaiting}) => {
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.log(e)
+        logger.log(e)
       })
   }
 

--- a/src/components/cards/getNetworkIdCard.js
+++ b/src/components/cards/getNetworkIdCard.js
@@ -3,8 +3,7 @@ import ApiCard from './apiCard'
 import runApiCall from '../../utils/runApiCall'
 
 const GetNetworkIdCard = ({api, onRawResponse, onResponse, onWaiting}) => {
-  const getNetworkIdClick = () =>
-    runApiCall(() => api.getNetworkId(), {onRawResponse, onResponse, onWaiting})
+  const getNetworkIdClick = () => runApiCall(() => api.getNetworkId(), {onRawResponse, onResponse, onWaiting})
 
   const apiProps = {
     apiName: 'getNetworkId',

--- a/src/components/cards/getNetworkIdCard.js
+++ b/src/components/cards/getNetworkIdCard.js
@@ -1,24 +1,10 @@
-import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
+import runApiCall from '../../utils/runApiCall'
 
 const GetNetworkIdCard = ({api, onRawResponse, onResponse, onWaiting}) => {
-  const getNetworkIdClick = () => {
-    onWaiting(true)
-    api
-      ?.getNetworkId()
-      .then((response) => {
-        onWaiting(false)
-        onRawResponse(response)
-        onResponse(response)
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.log(e)
-      })
-  }
+  const getNetworkIdClick = () =>
+    runApiCall(() => api.getNetworkId(), {onRawResponse, onResponse, onWaiting})
 
   const apiProps = {
     apiName: 'getNetworkId',

--- a/src/components/cards/getRewardAddressesCard.js
+++ b/src/components/cards/getRewardAddressesCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 import {getBech32AddressFromHex} from '../../utils/cslTools'
@@ -20,7 +21,7 @@ const GetRewardAddressesCard = ({api, onRawResponse, onResponse, onWaiting}) => 
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.log(e)
+        logger.log(e)
       })
   }
 

--- a/src/components/cards/getRewardAddressesCard.js
+++ b/src/components/cards/getRewardAddressesCard.js
@@ -5,9 +5,13 @@ import runApiCall from '../../utils/runApiCall'
 
 const GetRewardAddressesCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   const getRewardAddressesClick = () =>
-    runApiCall(() => api.getRewardAddresses(), {onRawResponse, onResponse, onWaiting}, {
-      parse: hexArrayToBech32Addresses,
-    })
+    runApiCall(
+      () => api.getRewardAddresses(),
+      {onRawResponse, onResponse, onWaiting},
+      {
+        parse: hexArrayToBech32Addresses,
+      },
+    )
 
   const apiProps = {
     apiName: 'getRewardAddresses',

--- a/src/components/cards/getRewardAddressesCard.js
+++ b/src/components/cards/getRewardAddressesCard.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import ApiCard from './apiCard'
-import {getBech32AddressFromHex} from '../../utils/cslTools'
+import {hexArrayToBech32Addresses} from '../../utils/cslTools'
 import runApiCall from '../../utils/runApiCall'
 
 const GetRewardAddressesCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   const getRewardAddressesClick = () =>
     runApiCall(() => api.getRewardAddresses(), {onRawResponse, onResponse, onWaiting}, {
-      parse: (hexAddresses) => hexAddresses.map(getBech32AddressFromHex),
+      parse: hexArrayToBech32Addresses,
     })
 
   const apiProps = {

--- a/src/components/cards/getRewardAddressesCard.js
+++ b/src/components/cards/getRewardAddressesCard.js
@@ -1,29 +1,13 @@
-import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 import {getBech32AddressFromHex} from '../../utils/cslTools'
+import runApiCall from '../../utils/runApiCall'
 
 const GetRewardAddressesCard = ({api, onRawResponse, onResponse, onWaiting}) => {
-  const getRewardAddressesClick = () => {
-    onWaiting(true)
-    api
-      ?.getRewardAddresses()
-      .then((hexAddresses) => {
-        onWaiting(false)
-        onRawResponse(hexAddresses)
-        const addresses = []
-        for (const hexAddr of hexAddresses) {
-          addresses.push(getBech32AddressFromHex(hexAddr))
-        }
-        onResponse(addresses)
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.log(e)
-      })
-  }
+  const getRewardAddressesClick = () =>
+    runApiCall(() => api.getRewardAddresses(), {onRawResponse, onResponse, onWaiting}, {
+      parse: (hexAddresses) => hexAddresses.map(getBech32AddressFromHex),
+    })
 
   const apiProps = {
     apiName: 'getRewardAddresses',

--- a/src/components/cards/getUnusedAddressCard.js
+++ b/src/components/cards/getUnusedAddressCard.js
@@ -5,9 +5,13 @@ import runApiCall from '../../utils/runApiCall'
 
 const GetUnusedAddressesCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   const getUnusedAddressesClick = () =>
-    runApiCall(() => api.getUnusedAddresses(), {onRawResponse, onResponse, onWaiting}, {
-      parse: hexArrayToBech32Addresses,
-    })
+    runApiCall(
+      () => api.getUnusedAddresses(),
+      {onRawResponse, onResponse, onWaiting},
+      {
+        parse: hexArrayToBech32Addresses,
+      },
+    )
 
   const apiProps = {
     apiName: 'getUnusedAddresses',

--- a/src/components/cards/getUnusedAddressCard.js
+++ b/src/components/cards/getUnusedAddressCard.js
@@ -1,29 +1,13 @@
-import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 import {getBech32AddressFromHex} from '../../utils/cslTools'
+import runApiCall from '../../utils/runApiCall'
 
 const GetUnusedAddressesCard = ({api, onRawResponse, onResponse, onWaiting}) => {
-  const getUnusedAddressesClick = () => {
-    onWaiting(true)
-    api
-      ?.getUnusedAddresses()
-      .then((hexAddresses) => {
-        onWaiting(false)
-        onRawResponse(hexAddresses)
-        const addresses = []
-        for (const hexAddr of hexAddresses) {
-          addresses.push(getBech32AddressFromHex(hexAddr))
-        }
-        onResponse(addresses)
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.log(e)
-      })
-  }
+  const getUnusedAddressesClick = () =>
+    runApiCall(() => api.getUnusedAddresses(), {onRawResponse, onResponse, onWaiting}, {
+      parse: (hexAddresses) => hexAddresses.map(getBech32AddressFromHex),
+    })
 
   const apiProps = {
     apiName: 'getUnusedAddresses',

--- a/src/components/cards/getUnusedAddressCard.js
+++ b/src/components/cards/getUnusedAddressCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 import {getBech32AddressFromHex} from '../../utils/cslTools'
@@ -20,7 +21,7 @@ const GetUnusedAddressesCard = ({api, onRawResponse, onResponse, onWaiting}) => 
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.log(e)
+        logger.log(e)
       })
   }
 

--- a/src/components/cards/getUnusedAddressCard.js
+++ b/src/components/cards/getUnusedAddressCard.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import ApiCard from './apiCard'
-import {getBech32AddressFromHex} from '../../utils/cslTools'
+import {hexArrayToBech32Addresses} from '../../utils/cslTools'
 import runApiCall from '../../utils/runApiCall'
 
 const GetUnusedAddressesCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   const getUnusedAddressesClick = () =>
     runApiCall(() => api.getUnusedAddresses(), {onRawResponse, onResponse, onWaiting}, {
-      parse: (hexAddresses) => hexAddresses.map(getBech32AddressFromHex),
+      parse: hexArrayToBech32Addresses,
     })
 
   const apiProps = {

--- a/src/components/cards/getUsedAddressCard.js
+++ b/src/components/cards/getUsedAddressCard.js
@@ -1,32 +1,16 @@
-import logger from '../../utils/logger'
 import React, {useState} from 'react'
 import {getBech32AddressFromHex} from '../../utils/cslTools'
 import ApiCardWithModal from './apiCardWithModal'
 import {ModalWindowContent, CommonStyles} from '../ui-constants'
+import runApiCall from '../../utils/runApiCall'
 
 const GetUsedAddresses = ({api, onRawResponse, onResponse, onWaiting}) => {
   const [usedAddressInput, setUsedAddressInput] = useState({page: 0, limit: 5})
 
-  const getUsedAddressesClick = () => {
-    onWaiting(true)
-    api
-      ?.getUsedAddresses(usedAddressInput)
-      .then((hexAddresses) => {
-        onWaiting(false)
-        onRawResponse(hexAddresses)
-        const addresses = []
-        for (const hexAddr of hexAddresses) {
-          addresses.push(getBech32AddressFromHex(hexAddr))
-        }
-        onResponse(addresses)
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.log(e)
-      })
-  }
+  const getUsedAddressesClick = () =>
+    runApiCall(() => api.getUsedAddresses(usedAddressInput), {onRawResponse, onResponse, onWaiting}, {
+      parse: (hexAddresses) => hexAddresses.map(getBech32AddressFromHex),
+    })
 
   const apiProps = {
     buttonLabel: 'getUsedAddresses',

--- a/src/components/cards/getUsedAddressCard.js
+++ b/src/components/cards/getUsedAddressCard.js
@@ -1,5 +1,5 @@
 import React, {useState} from 'react'
-import {getBech32AddressFromHex} from '../../utils/cslTools'
+import {hexArrayToBech32Addresses} from '../../utils/cslTools'
 import ApiCardWithModal from './apiCardWithModal'
 import InputWithLabel from '../inputWithLabel'
 import runApiCall from '../../utils/runApiCall'
@@ -9,7 +9,7 @@ const GetUsedAddresses = ({api, onRawResponse, onResponse, onWaiting}) => {
 
   const getUsedAddressesClick = () =>
     runApiCall(() => api.getUsedAddresses(usedAddressInput), {onRawResponse, onResponse, onWaiting}, {
-      parse: (hexAddresses) => hexAddresses.map(getBech32AddressFromHex),
+      parse: hexArrayToBech32Addresses,
     })
 
   const apiProps = {

--- a/src/components/cards/getUsedAddressCard.js
+++ b/src/components/cards/getUsedAddressCard.js
@@ -1,7 +1,7 @@
 import React, {useState} from 'react'
 import {getBech32AddressFromHex} from '../../utils/cslTools'
 import ApiCardWithModal from './apiCardWithModal'
-import {ModalWindowContent, CommonStyles} from '../ui-constants'
+import InputWithLabel from '../inputWithLabel'
 import runApiCall from '../../utils/runApiCall'
 
 const GetUsedAddresses = ({api, onRawResponse, onResponse, onWaiting}) => {
@@ -20,34 +20,24 @@ const GetUsedAddresses = ({api, onRawResponse, onResponse, onWaiting}) => {
   return (
     <ApiCardWithModal {...apiProps}>
       <div className="grid gap-6 mb-6 md:grid-cols-2 px-2">
-        <div>
-          <label htmlFor="page" className={ModalWindowContent.contentLabelStyle}>
-            Page
-          </label>
-          <input
-            type="number"
-            min="0"
-            id="page"
-            className={CommonStyles.inputStyles}
-            placeholder="0"
-            value={usedAddressInput.page}
-            onChange={(event) => setUsedAddressInput({...usedAddressInput, page: Number(event.target.value)})}
-          />
-        </div>
-        <div>
-          <label htmlFor="limit" className={ModalWindowContent.contentLabelStyle}>
-            Limit
-          </label>
-          <input
-            type="number"
-            min="0"
-            id="limit"
-            className={CommonStyles.inputStyles}
-            placeholder="5"
-            value={usedAddressInput.limit}
-            onChange={(event) => setUsedAddressInput({...usedAddressInput, limit: Number(event.target.value)})}
-          />
-        </div>
+        <InputWithLabel
+          inputName="Page"
+          type="number"
+          min="0"
+          placeholder="0"
+          inputValue={usedAddressInput.page}
+          onChangeFunction={(event) => setUsedAddressInput({...usedAddressInput, page: Number(event.target.value)})}
+          wrapperClassName=""
+        />
+        <InputWithLabel
+          inputName="Limit"
+          type="number"
+          min="0"
+          placeholder="5"
+          inputValue={usedAddressInput.limit}
+          onChangeFunction={(event) => setUsedAddressInput({...usedAddressInput, limit: Number(event.target.value)})}
+          wrapperClassName=""
+        />
       </div>
     </ApiCardWithModal>
   )

--- a/src/components/cards/getUsedAddressCard.js
+++ b/src/components/cards/getUsedAddressCard.js
@@ -8,9 +8,13 @@ const GetUsedAddresses = ({api, onRawResponse, onResponse, onWaiting}) => {
   const [usedAddressInput, setUsedAddressInput] = useState({page: 0, limit: 5})
 
   const getUsedAddressesClick = () =>
-    runApiCall(() => api.getUsedAddresses(usedAddressInput), {onRawResponse, onResponse, onWaiting}, {
-      parse: hexArrayToBech32Addresses,
-    })
+    runApiCall(
+      () => api.getUsedAddresses(usedAddressInput),
+      {onRawResponse, onResponse, onWaiting},
+      {
+        parse: hexArrayToBech32Addresses,
+      },
+    )
 
   const apiProps = {
     buttonLabel: 'getUsedAddresses',

--- a/src/components/cards/getUsedAddressCard.js
+++ b/src/components/cards/getUsedAddressCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React, {useState} from 'react'
 import {getBech32AddressFromHex} from '../../utils/cslTools'
 import ApiCardWithModal from './apiCardWithModal'
@@ -23,7 +24,7 @@ const GetUsedAddresses = ({api, onRawResponse, onResponse, onWaiting}) => {
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.log(e)
+        logger.log(e)
       })
   }
 

--- a/src/components/cards/getUtxosCard.js
+++ b/src/components/cards/getUtxosCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React, {useState} from 'react'
 import ApiCardWithModal from './apiCardWithModal'
 import {ModalWindowContent, CommonStyles} from '../ui-constants'
@@ -24,7 +25,7 @@ const GetUtxosCard = ({api, onRawResponse, onResponse, onWaiting}) => {
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.log(e)
+        logger.log(e)
       })
   }
 

--- a/src/components/cards/getUtxosCard.js
+++ b/src/components/cards/getUtxosCard.js
@@ -1,33 +1,18 @@
-import logger from '../../utils/logger'
 import React, {useState} from 'react'
 import ApiCardWithModal from './apiCardWithModal'
 import {ModalWindowContent, CommonStyles} from '../ui-constants'
 import {getUtxoFromHex} from '../../utils/cslTools'
+import runApiCall from '../../utils/runApiCall'
 
 const GetUtxosCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   const [getUtxosInput, setGetUtxosInput] = useState({amount: '', page: 0, limit: 10})
 
-  const getUtxosClick = () => {
-    onWaiting(true)
-    api
-      ?.getUtxos(getUtxosInput.amount, {page: getUtxosInput.page, limit: getUtxosInput.limit})
-      .then((hexUtxos) => {
-        onWaiting(false)
-        onRawResponse(hexUtxos)
-        let utxos = []
-        for (const hexUtxo of hexUtxos) {
-          const utxo = getUtxoFromHex(hexUtxo)
-          utxos.push(utxo)
-        }
-        onResponse(utxos)
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.log(e)
-      })
-  }
+  const getUtxosClick = () =>
+    runApiCall(
+      () => api.getUtxos(getUtxosInput.amount, {page: getUtxosInput.page, limit: getUtxosInput.limit}),
+      {onRawResponse, onResponse, onWaiting},
+      {parse: (hexUtxos) => hexUtxos.map(getUtxoFromHex)},
+    )
 
   const apiProps = {
     buttonLabel: 'getUtxos',

--- a/src/components/cards/getUtxosCard.js
+++ b/src/components/cards/getUtxosCard.js
@@ -2,7 +2,7 @@ import React, {useState} from 'react'
 import ApiCardWithModal from './apiCardWithModal'
 import {ModalWindowContent} from '../ui-constants'
 import InputWithLabel from '../inputWithLabel'
-import {getUtxoFromHex} from '../../utils/cslTools'
+import {hexArrayToUtxos} from '../../utils/cslTools'
 import runApiCall from '../../utils/runApiCall'
 
 const GetUtxosCard = ({api, onRawResponse, onResponse, onWaiting}) => {
@@ -12,7 +12,7 @@ const GetUtxosCard = ({api, onRawResponse, onResponse, onWaiting}) => {
     runApiCall(
       () => api.getUtxos(getUtxosInput.amount, {page: getUtxosInput.page, limit: getUtxosInput.limit}),
       {onRawResponse, onResponse, onWaiting},
-      {parse: (hexUtxos) => hexUtxos.map(getUtxoFromHex)},
+      {parse: hexArrayToUtxos},
     )
 
   const apiProps = {

--- a/src/components/cards/getUtxosCard.js
+++ b/src/components/cards/getUtxosCard.js
@@ -1,6 +1,7 @@
 import React, {useState} from 'react'
 import ApiCardWithModal from './apiCardWithModal'
-import {ModalWindowContent, CommonStyles} from '../ui-constants'
+import {ModalWindowContent} from '../ui-constants'
+import InputWithLabel from '../inputWithLabel'
 import {getUtxoFromHex} from '../../utils/cslTools'
 import runApiCall from '../../utils/runApiCall'
 
@@ -22,48 +23,32 @@ const GetUtxosCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   return (
     <ApiCardWithModal {...apiProps}>
       <div className={ModalWindowContent.contentPadding}>
-        <label htmlFor="amount" className={ModalWindowContent.contentLabelStyle}>
-          Amount (lovelaces)
-        </label>
-        <input
+        <InputWithLabel
+          inputName="Amount (lovelaces)"
           type="number"
           min="0"
-          id="amount"
-          className={CommonStyles.inputStyles}
-          placeholder=""
-          value={getUtxosInput.amount}
-          onChange={(event) => setGetUtxosInput({...getUtxosInput, amount: event.target.value})}
+          inputValue={getUtxosInput.amount}
+          onChangeFunction={(event) => setGetUtxosInput({...getUtxosInput, amount: event.target.value})}
+          wrapperClassName=""
         />
       </div>
       <div className="grid gap-4 mb-3 md:grid-cols-2 px-2">
-        <div>
-          <label htmlFor="page" className={ModalWindowContent.contentLabelStyle}>
-            Page
-          </label>
-          <input
-            type="number"
-            min="0"
-            id="page"
-            className={CommonStyles.inputStyles}
-            placeholder=""
-            value={getUtxosInput.page}
-            onChange={(event) => setGetUtxosInput({...getUtxosInput, page: Number(event.target.value)})}
-          />
-        </div>
-        <div>
-          <label htmlFor="limit" className={ModalWindowContent.contentLabelStyle}>
-            Limit
-          </label>
-          <input
-            type="number"
-            min="0"
-            id="limit"
-            className={CommonStyles.inputStyles}
-            placeholder=""
-            value={getUtxosInput.limit}
-            onChange={(event) => setGetUtxosInput({...getUtxosInput, limit: Number(event.target.value)})}
-          />
-        </div>
+        <InputWithLabel
+          inputName="Page"
+          type="number"
+          min="0"
+          inputValue={getUtxosInput.page}
+          onChangeFunction={(event) => setGetUtxosInput({...getUtxosInput, page: Number(event.target.value)})}
+          wrapperClassName=""
+        />
+        <InputWithLabel
+          inputName="Limit"
+          type="number"
+          min="0"
+          inputValue={getUtxosInput.limit}
+          onChangeFunction={(event) => setGetUtxosInput({...getUtxosInput, limit: Number(event.target.value)})}
+          wrapperClassName=""
+        />
       </div>
     </ApiCardWithModal>
   )

--- a/src/components/cards/govActions/authCCPanel.js
+++ b/src/components/cards/govActions/authCCPanel.js
@@ -1,9 +1,6 @@
 import React, {useState} from 'react'
 import InputWithLabel from '../../inputWithLabel'
-import {
-  getCommitteeHotAuth,
-  getCertOfNewCommitteeHotAuth,
-} from '../../../utils/cslTools'
+import {getCommitteeHotAuth, getCertOfNewCommitteeHotAuth} from '../../../utils/cslTools'
 import GovToolsPanel from '../govToolsPanel'
 import buildCert from '../../../utils/buildCert'
 

--- a/src/components/cards/govActions/authCCPanel.js
+++ b/src/components/cards/govActions/authCCPanel.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import React, {useState} from 'react'
 import InputWithLabel from '../../inputWithLabel'
 import {
@@ -41,7 +42,7 @@ const AuthCCPanel = (props) => {
       handleAddingCertInTx(certBuilder)
       onWaiting(false)
     } catch (error) {
-      console.error(error)
+      logger.error(error)
       onWaiting(false)
       onError()
     }

--- a/src/components/cards/govActions/authCCPanel.js
+++ b/src/components/cards/govActions/authCCPanel.js
@@ -1,4 +1,3 @@
-import logger from '../../../utils/logger'
 import React, {useState} from 'react'
 import InputWithLabel from '../../inputWithLabel'
 import {
@@ -6,6 +5,7 @@ import {
   getCertOfNewCommitteeHotAuth,
 } from '../../../utils/cslTools'
 import GovToolsPanel from '../govToolsPanel'
+import buildCert from '../../../utils/buildCert'
 
 const AuthCCPanel = (props) => {
   const {onWaiting, onError, getters, setters, handleInputCreds} = props
@@ -15,23 +15,18 @@ const AuthCCPanel = (props) => {
   const [ccColdInputValue, setCCColdCredInputValue] = useState('')
   const [ccHotInputValue, setCCHotCredInputValue] = useState('')
 
-  const buildCCAuthCert = () => {
-    onWaiting(true)
-
-    // build CC auth cert
-    const certBuilder = getCertBuilder()
-    try {
-
+  const buildCCAuthCert = () =>
+    buildCert(getCertBuilder, {onWaiting, onError}, (certBuilder) => {
       // cold credential
       const coldCred = handleInputCreds(ccColdInputValue)
       if (coldCred == null) {
-        return null
+        return
       }
-      
+
       // hot credential
       const hotCred = handleInputCreds(ccHotInputValue)
       if (hotCred == null) {
-        return null
+        return
       }
 
       // Create cert object
@@ -40,13 +35,7 @@ const AuthCCPanel = (props) => {
       certBuilder.add(getCertOfNewCommitteeHotAuth(committeeHotAuthCert))
       // adding the cert to the certStorage
       handleAddingCertInTx(certBuilder)
-      onWaiting(false)
-    } catch (error) {
-      logger.error(error)
-      onWaiting(false)
-      onError()
-    }
-  }
+    })
 
   const panelProps = {
     buttonName: 'Build Cert',

--- a/src/components/cards/govActions/dRepRegistrationPanel.js
+++ b/src/components/cards/govActions/dRepRegistrationPanel.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import React, {useState} from 'react'
 import GovToolsPanel from '../govToolsPanel'
 import InputWithLabel from '../../inputWithLabel'
@@ -34,7 +35,7 @@ const DRepRegistrationPanel = (props) => {
       handleAddingCertInTx(certBuilder)
       onWaiting(false)
     } catch (error) {
-      console.error(error)
+      logger.error(error)
       onWaiting(false)
       onError()
     }

--- a/src/components/cards/govActions/dRepRegistrationPanel.js
+++ b/src/components/cards/govActions/dRepRegistrationPanel.js
@@ -1,9 +1,9 @@
-import logger from '../../../utils/logger'
 import React, {useState} from 'react'
 import GovToolsPanel from '../govToolsPanel'
 import InputWithLabel from '../../inputWithLabel'
 import {getAnchor, getCertOfNewDRepReg, getDRepRegCert, getDRepRegWithAnchorCert} from '../../../utils/cslTools'
 import {bytesToHex} from '../../../utils/utils'
+import buildCert from '../../../utils/buildCert'
 
 const DRepRegistrationPanel = (props) => {
   const {onWaiting, onError, getters, setters, handleInputCreds} = props
@@ -15,10 +15,8 @@ const DRepRegistrationPanel = (props) => {
   const [metadataURL, setMetadataURL] = useState('')
   const [metadataHash, setMetadataHash] = useState('')
 
-  const buildDRepRegistrationCert = () => {
-    onWaiting(true)
-    const certBuilder = getCertBuilder()
-    try {
+  const buildDRepRegistrationCert = () =>
+    buildCert(getCertBuilder, {onWaiting, onError}, (certBuilder) => {
       const dRepCred = handleInputCreds(dRepIdInputValue)
       let dRepRegCert = null
       if (metadataURL.length > 0) {
@@ -33,13 +31,7 @@ const DRepRegistrationPanel = (props) => {
       }
       certBuilder.add(getCertOfNewDRepReg(dRepRegCert))
       handleAddingCertInTx(certBuilder)
-      onWaiting(false)
-    } catch (error) {
-      logger.error(error)
-      onWaiting(false)
-      onError()
-    }
-  }
+    })
 
   const panelProps = {
     buttonName: 'Build Cert',

--- a/src/components/cards/govActions/dRepRetirementPanel.js
+++ b/src/components/cards/govActions/dRepRetirementPanel.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import React, {useState} from 'react'
 import GovToolsPanel from '../govToolsPanel'
 import InputWithLabel from '../../inputWithLabel'
@@ -20,7 +21,7 @@ const DRepRetirementPanel = (props) => {
       handleAddingCertInTx(certBuilder)
       onWaiting(false)
     } catch (error) {
-      console.error(error)
+      logger.error(error)
       onWaiting(false)
       onError()
     }

--- a/src/components/cards/govActions/dRepRetirementPanel.js
+++ b/src/components/cards/govActions/dRepRetirementPanel.js
@@ -1,8 +1,8 @@
-import logger from '../../../utils/logger'
 import React, {useState} from 'react'
 import GovToolsPanel from '../govToolsPanel'
 import InputWithLabel from '../../inputWithLabel'
 import {getCertOfNewDRepRetirement, getDRepRetirementCert} from '../../../utils/cslTools'
+import buildCert from '../../../utils/buildCert'
 
 const DRepRetirementPanel = (props) => {
   const {onWaiting, onError, getters, setters, handleInputCreds} = props
@@ -11,21 +11,13 @@ const DRepRetirementPanel = (props) => {
   const {dRepIdInputValue, getCertBuilder} = getters
   const [depositRefundAmount, setDepositRefundAmount] = useState('2000000')
 
-  const buildDRepRetirementCert = () => {
-    onWaiting(true)
-    const certBuilder = getCertBuilder()
-    try {
+  const buildDRepRetirementCert = () =>
+    buildCert(getCertBuilder, {onWaiting, onError}, (certBuilder) => {
       const dRepCred = handleInputCreds(dRepIdInputValue)
       const dRepRetirementCert = getDRepRetirementCert(dRepCred, depositRefundAmount)
       certBuilder.add(getCertOfNewDRepRetirement(dRepRetirementCert))
       handleAddingCertInTx(certBuilder)
-      onWaiting(false)
-    } catch (error) {
-      logger.error(error)
-      onWaiting(false)
-      onError()
-    }
-  }
+    })
 
   const panelProps = {
     buttonName: 'Build Cert',

--- a/src/components/cards/govActions/dRepUpdatePanel.js
+++ b/src/components/cards/govActions/dRepUpdatePanel.js
@@ -1,4 +1,3 @@
-import logger from '../../../utils/logger'
 import React, {useState} from 'react'
 import GovToolsPanel from '../govToolsPanel'
 import InputWithLabel from '../../inputWithLabel'
@@ -9,6 +8,7 @@ import {
   getDRepUpdateWithAnchorCert,
 } from '../../../utils/cslTools'
 import {getRandomHex} from '../../../utils/helpFunctions'
+import buildCert from '../../../utils/buildCert'
 
 const DRepUpdatePanel = (props) => {
   const {onWaiting, onError, getters, setters, handleInputCreds} = props
@@ -19,10 +19,8 @@ const DRepUpdatePanel = (props) => {
   const [metadataURL, setMetadataURL] = useState('')
   const [metadataHash, setMetadataHash] = useState('')
 
-  const buildDRepUpdateCert = () => {
-    onWaiting(true)
-    const certBuilder = getCertBuilder()
-    try {
+  const buildDRepUpdateCert = () =>
+    buildCert(getCertBuilder, {onWaiting, onError}, (certBuilder) => {
       const dRepCred = handleInputCreds(dRepIdInputValue)
       let dRepUpdateCert = null
       if (metadataURL.length > 0) {
@@ -34,13 +32,7 @@ const DRepUpdatePanel = (props) => {
       }
       certBuilder.add(getCertOfNewDRepUpdate(dRepUpdateCert))
       handleAddingCertInTx(certBuilder)
-      onWaiting(false)
-    } catch (error) {
-      logger.error(error)
-      onWaiting(false)
-      onError()
-    }
-  }
+    })
 
   const panelProps = {
     buttonName: 'Build Cert',

--- a/src/components/cards/govActions/dRepUpdatePanel.js
+++ b/src/components/cards/govActions/dRepUpdatePanel.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import React, {useState} from 'react'
 import GovToolsPanel from '../govToolsPanel'
 import InputWithLabel from '../../inputWithLabel'
@@ -35,7 +36,7 @@ const DRepUpdatePanel = (props) => {
       handleAddingCertInTx(certBuilder)
       onWaiting(false)
     } catch (error) {
-      console.error(error)
+      logger.error(error)
       onWaiting(false)
       onError()
     }

--- a/src/components/cards/govActions/regStakeKeyPanel.js
+++ b/src/components/cards/govActions/regStakeKeyPanel.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import React, {useState} from 'react'
 import CheckboxWithLabel from '../../checkboxWithLabel'
 import InputWithLabel from '../../inputWithLabel'
@@ -17,7 +18,7 @@ const RegisterStakeKeyPanel = (props) => {
 
   const handleUseConwayCert = () => {
     setUseConway(!useConway)
-    console.debug(`[dApp][RegisterStakeKeyPanel] use Conway Stake Registration Certificate is set: ${!useConway}`)
+    logger.debug(`[dApp][RegisterStakeKeyPanel] use Conway Stake Registration Certificate is set: ${!useConway}`)
   }
 
   const buildRegStakeKey = () => {
@@ -36,7 +37,7 @@ const RegisterStakeKeyPanel = (props) => {
       handleAddingCertInTx(certBuilder)
       onWaiting(false)
     } catch (error) {
-      console.error(error)
+      logger.error(error)
       onWaiting(false)
       onError()
     }

--- a/src/components/cards/govActions/regStakeKeyPanel.js
+++ b/src/components/cards/govActions/regStakeKeyPanel.js
@@ -5,6 +5,7 @@ import InputWithLabel from '../../inputWithLabel'
 import GovToolsPanel from '../govToolsPanel'
 import {protocolParams} from '../../../utils/networkConfig'
 import {getCertOfNewStakeReg, getStakeKeyRegCert, getStakeKeyRegCertWithCoin} from '../../../utils/cslTools'
+import buildCert from '../../../utils/buildCert'
 
 const RegisterStakeKeyPanel = (props) => {
   const {onWaiting, onError, getters, setters, handleInputCreds} = props
@@ -21,27 +22,16 @@ const RegisterStakeKeyPanel = (props) => {
     logger.debug(`[dApp][RegisterStakeKeyPanel] use Conway Stake Registration Certificate is set: ${!useConway}`)
   }
 
-  const buildRegStakeKey = () => {
-    onWaiting(true)
-    const certBuilder = getCertBuilder()
-    try {
+  const buildRegStakeKey = () =>
+    buildCert(getCertBuilder, {onWaiting, onError}, (certBuilder) => {
       // building StakeKeyRegCert
       const stakeCred = handleInputCreds(stakeKeyHash)
-      let stakeKeyRegCert
-      if (useConway) {
-        stakeKeyRegCert = getStakeKeyRegCertWithCoin(stakeCred, stakeDepositAmount)
-      } else {
-        stakeKeyRegCert = getStakeKeyRegCert(stakeCred)
-      }
+      const stakeKeyRegCert = useConway
+        ? getStakeKeyRegCertWithCoin(stakeCred, stakeDepositAmount)
+        : getStakeKeyRegCert(stakeCred)
       certBuilder.add(getCertOfNewStakeReg(stakeKeyRegCert))
       handleAddingCertInTx(certBuilder)
-      onWaiting(false)
-    } catch (error) {
-      logger.error(error)
-      onWaiting(false)
-      onError()
-    }
-  }
+    })
 
   const panelProps = {
     buttonName: 'Build Cert',

--- a/src/components/cards/govActions/unregStakeKeyPanel.js
+++ b/src/components/cards/govActions/unregStakeKeyPanel.js
@@ -5,6 +5,7 @@ import CheckboxWithLabel from '../../checkboxWithLabel'
 import InputWithLabel from '../../inputWithLabel'
 import {protocolParams} from '../../../utils/networkConfig'
 import {getCertOfNewStakeDereg, getStakeKeyDeregCert, getStakeKeyDeregCertWithCoin} from '../../../utils/cslTools'
+import buildCert from '../../../utils/buildCert'
 
 const UnregisterStakeKeyPanel = (props) => {
   const {onWaiting, onError, getters, setters, handleInputCreds} = props
@@ -20,26 +21,15 @@ const UnregisterStakeKeyPanel = (props) => {
     logger.debug(`[dApp][UnregisterStakeKeyPanel] use Conway Stake Registration Certificate is set: ${!useConway}`)
   }
 
-  const buildUnregStakeKey = () => {
-    onWaiting(true)
-    const certBuilder = getCertBuilder()
-    try {
+  const buildUnregStakeKey = () =>
+    buildCert(getCertBuilder, {onWaiting, onError}, (certBuilder) => {
       const stakeCred = handleInputCreds(stakeKeyHash)
-      let stakeKeyDeregCert
-      if (useConway) {
-        stakeKeyDeregCert = getStakeKeyDeregCertWithCoin(stakeCred, stakeDepositRefundAmount)
-      } else {
-        stakeKeyDeregCert = getStakeKeyDeregCert(stakeCred)
-      }
+      const stakeKeyDeregCert = useConway
+        ? getStakeKeyDeregCertWithCoin(stakeCred, stakeDepositRefundAmount)
+        : getStakeKeyDeregCert(stakeCred)
       certBuilder.add(getCertOfNewStakeDereg(stakeKeyDeregCert))
       handleAddingCertInTx(certBuilder)
-      onWaiting(false)
-    } catch (error) {
-      logger.error(error)
-      onWaiting(false)
-      onError()
-    }
-  }
+    })
 
   const panelProps = {
     buttonName: 'Build Cert',

--- a/src/components/cards/govActions/unregStakeKeyPanel.js
+++ b/src/components/cards/govActions/unregStakeKeyPanel.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import React, {useState} from 'react'
 import GovToolsPanel from '../govToolsPanel'
 import CheckboxWithLabel from '../../checkboxWithLabel'
@@ -16,7 +17,7 @@ const UnregisterStakeKeyPanel = (props) => {
 
   const handleUseConwayCert = () => {
     setUseConway(!useConway)
-    console.debug(`[dApp][UnregisterStakeKeyPanel] use Conway Stake Registration Certificate is set: ${!useConway}`)
+    logger.debug(`[dApp][UnregisterStakeKeyPanel] use Conway Stake Registration Certificate is set: ${!useConway}`)
   }
 
   const buildUnregStakeKey = () => {
@@ -34,7 +35,7 @@ const UnregisterStakeKeyPanel = (props) => {
       handleAddingCertInTx(certBuilder)
       onWaiting(false)
     } catch (error) {
-      console.error(error)
+      logger.error(error)
       onWaiting(false)
       onError()
     }

--- a/src/components/cards/govActions/voteDelegationPanel.js
+++ b/src/components/cards/govActions/voteDelegationPanel.js
@@ -1,4 +1,3 @@
-import logger from '../../../utils/logger'
 import {useState} from 'react'
 import InputWithLabel from '../../inputWithLabel'
 import {
@@ -11,6 +10,7 @@ import {
   keyHashFromHex,
 } from '../../../utils/cslTools'
 import GovToolsPanel from '../govToolsPanel'
+import buildCert from '../../../utils/buildCert'
 
 const VoteDelegationPanel = (props) => {
   const {onWaiting, onError, getters, setters, handleInputCreds, handleDrepId} = props
@@ -21,12 +21,8 @@ const VoteDelegationPanel = (props) => {
 
   const suitableStake = regPubStakeKey.length > 0 ? regPubStakeKey : unregPubStakeKey
 
-  const buildVoteDelegationCert = () => {
-    onWaiting(true)
-
-    // build vote cert
-    const certBuilder = getCertBuilder()
-    try {
+  const buildVoteDelegationCert = () =>
+    buildCert(getCertBuilder, {onWaiting, onError}, (certBuilder) => {
       let targetDRep
       if (dRepIdInputValue.toUpperCase() === 'ABSTAIN') {
         targetDRep = getDRepAbstain()
@@ -54,7 +50,7 @@ const VoteDelegationPanel = (props) => {
       }
       const stakeCred = handleInputCreds(pubStake)
       if (stakeCred == null) {
-        return null
+        return
       }
       // Create cert object
       if (targetDRep) {
@@ -64,13 +60,7 @@ const VoteDelegationPanel = (props) => {
         // adding the cert to the certStorage
         handleAddingCertInTx(certBuilder)
       }
-      onWaiting(false)
-    } catch (error) {
-      logger.error(error)
-      onWaiting(false)
-      onError()
-    }
-  }
+    })
 
   const panelProps = {
     buttonName: 'Build Cert',

--- a/src/components/cards/govActions/voteDelegationPanel.js
+++ b/src/components/cards/govActions/voteDelegationPanel.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import {useState} from 'react'
 import InputWithLabel from '../../inputWithLabel'
 import {
@@ -65,7 +66,7 @@ const VoteDelegationPanel = (props) => {
       }
       onWaiting(false)
     } catch (error) {
-      console.error(error)
+      logger.error(error)
       onWaiting(false)
       onError()
     }

--- a/src/components/cards/govActions/votePanel.js
+++ b/src/components/cards/govActions/votePanel.js
@@ -1,4 +1,3 @@
-import logger from '../../../utils/logger'
 import {useState} from 'react'
 import InputWithLabel from '../../inputWithLabel'
 import GovToolsPanel from '../govToolsPanel'
@@ -11,6 +10,7 @@ import {
 } from '../../../utils/cslTools'
 import SelectWithLabel from '../../selectWithLabel'
 import {getRandomHex} from '../../../utils/helpFunctions'
+import buildCert from '../../../utils/buildCert'
 
 const VotePanel = (props) => {
   const {onWaiting, onError, getters, setters, handleDrepId} = props
@@ -33,10 +33,8 @@ const VotePanel = (props) => {
     setVotingChoice(event.target.value)
   }
 
-  const buildVote = () => {
-    onWaiting(true)
-    const votingBuilder = getVotingBuilder()
-    try {
+  const buildVote = () =>
+    buildCert(getVotingBuilder, {onWaiting, onError}, (votingBuilder) => {
       // Getting voter
       const dRepCreds = handleDrepId(dRepIdInputValue)
       const voter = getVoter(dRepCreds)
@@ -55,13 +53,7 @@ const VotePanel = (props) => {
       // Add vote to vote builder
       votingBuilder.add(voter, govActionId, votingProcedure)
       handleAddingVotesInTx(votingBuilder)
-      onWaiting(false)
-    } catch (error) {
-      logger.error(error)
-      onWaiting(false)
-      onError()
-    }
-  }
+    })
 
   const panelProps = {
     buttonName: 'Build Vote',

--- a/src/components/cards/govActions/votePanel.js
+++ b/src/components/cards/govActions/votePanel.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import {useState} from 'react'
 import InputWithLabel from '../../inputWithLabel'
 import GovToolsPanel from '../govToolsPanel'
@@ -56,7 +57,7 @@ const VotePanel = (props) => {
       handleAddingVotesInTx(votingBuilder)
       onWaiting(false)
     } catch (error) {
-      console.error(error)
+      logger.error(error)
       onWaiting(false)
       onError()
     }

--- a/src/components/cards/govToolsPanel.js
+++ b/src/components/cards/govToolsPanel.js
@@ -1,10 +1,11 @@
+import logger from '../../utils/logger'
 import React from 'react'
 import {ModalWindowContent} from '../ui-constants'
 
 const GovToolsPanel = (props) => {
   const {buttonName, certLabel, clickFunction, children} = props
   const handleAction = () => {
-    console.log(`[dApp][GovToolsPanel][${certLabel}] Building is called`)
+    logger.log(`[dApp][GovToolsPanel][${certLabel}] Building is called`)
     // action here
     clickFunction()
   }

--- a/src/components/cards/isEnabledCard.js
+++ b/src/components/cards/isEnabledCard.js
@@ -1,23 +1,9 @@
-import logger from '../../utils/logger'
 import ApiCard from './apiCard'
+import runApiCall from '../../utils/runApiCall'
 
 const IsEnabledCard = ({onRawResponse, onResponse, onWaiting, selectedWallet}) => {
-  const isDisabledClick = () => {
-    onWaiting(true)
-    window.cardano[selectedWallet]
-      ?.isEnabled()
-      .then((enabled) => {
-        onWaiting(false)
-        onRawResponse(enabled)
-        onResponse(enabled)
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.error(e)
-      })
-  }
+  const isDisabledClick = () =>
+    runApiCall(() => window.cardano[selectedWallet].isEnabled(), {onRawResponse, onResponse, onWaiting})
 
   const apiProps = {
     apiName: 'isEnabled',

--- a/src/components/cards/isEnabledCard.js
+++ b/src/components/cards/isEnabledCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import ApiCard from './apiCard'
 
 const IsEnabledCard = ({onRawResponse, onResponse, onWaiting, selectedWallet}) => {
@@ -14,7 +15,7 @@ const IsEnabledCard = ({onRawResponse, onResponse, onWaiting, selectedWallet}) =
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.error(e)
+        logger.error(e)
       })
   }
 

--- a/src/components/cards/listNFTsCard.js
+++ b/src/components/cards/listNFTsCard.js
@@ -1,24 +1,10 @@
-import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
+import runApiCall from '../../utils/runApiCall'
 
 const ListNFTsCard = ({api, onRawResponse, onResponse, onWaiting}) => {
-  const listNFTsClick = () => {
-    onWaiting(true)
-    api?.experimental
-      .listNFTs()
-      .then((response) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(response)
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.log(e)
-      })
-  }
+  const listNFTsClick = () =>
+    runApiCall(() => api.experimental.listNFTs(), {onRawResponse, onResponse, onWaiting}, {rawText: () => ''})
 
   const apiProps = {
     apiName: 'listNFTs',

--- a/src/components/cards/listNFTsCard.js
+++ b/src/components/cards/listNFTsCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React from 'react'
 import ApiCard from './apiCard'
 
@@ -15,7 +16,7 @@ const ListNFTsCard = ({api, onRawResponse, onResponse, onWaiting}) => {
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.log(e)
+        logger.log(e)
       })
   }
 

--- a/src/components/cards/signDataCard.js
+++ b/src/components/cards/signDataCard.js
@@ -2,9 +2,10 @@ import logger from '../../utils/logger'
 import React, {useState} from 'react'
 import ApiCardWithModal from './apiCardWithModal'
 import {Buffer} from 'buffer'
-import {CommonStyles, ModalWindowContent} from '../ui-constants'
+import {ModalWindowContent} from '../ui-constants'
 import {getBech32AddressFromHex} from '../../utils/cslTools'
 import SelectWithLabel from '../selectWithLabel'
+import InputWithLabel from '../inputWithLabel'
 
 const SignDataCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   const [message, setMessage] = useState('')
@@ -101,38 +102,24 @@ const SignDataCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   return (
     <ApiCardWithModal {...apiProps}>
       <div className={ModalWindowContent.contentPadding}>
-        <div>
-          <label htmlFor="signAddress" className={ModalWindowContent.contentLabelStyle}>
-            Address (optional - defaults to reward address)
-          </label>
-          <input
-            type="text"
-            id="signAddress"
-            className={CommonStyles.inputStyles}
-            placeholder=""
-            value={address}
-            onChange={(event) => setAddress(event.target.value)}
-          />
-        </div>
+        <InputWithLabel
+          inputName="Address (optional - defaults to reward address)"
+          inputValue={address}
+          onChangeFunction={(event) => setAddress(event.target.value)}
+          wrapperClassName=""
+        />
         <SelectWithLabel
           selectName="Message Encoding"
           selectArray={encodingOptions}
           onChangeFunction={(event) => setEncodingType(event.target.value)}
           defaultValue={encodingType}
         />
-        <div className="mt-3">
-          <label htmlFor="signMessage" className={ModalWindowContent.contentLabelStyle}>
-            Message to sign
-          </label>
-          <input
-            type="text"
-            id="signMessage"
-            className={CommonStyles.inputStyles}
-            placeholder={encodingType === 'hex' ? 'e.g., 0x48656c6c6f or 48656c6c6f' : 'e.g., Hello'}
-            value={message}
-            onChange={(event) => setMessage(event.target.value)}
-          />
-        </div>
+        <InputWithLabel
+          inputName="Message to sign"
+          inputValue={message}
+          onChangeFunction={(event) => setMessage(event.target.value)}
+          placeholder={encodingType === 'hex' ? 'e.g., 0x48656c6c6f or 48656c6c6f' : 'e.g., Hello'}
+        />
       </div>
     </ApiCardWithModal>
   )

--- a/src/components/cards/signDataCard.js
+++ b/src/components/cards/signDataCard.js
@@ -57,21 +57,21 @@ const SignDataCard = ({api, onRawResponse, onResponse, onWaiting}) => {
     try {
       const address = await getAddress()
       const payloadHex = getPayloadHex(message, encodingType)
-      
+
       // Log the inputs for debugging
-      logger.log('SignData inputs:', { address, payloadHex, originalMessage: message, encodingType })
-      
+      logger.log('SignData inputs:', {address, payloadHex, originalMessage: message, encodingType})
+
       const signDataResponse = await api?.signData(address, payloadHex)
-      
+
       // Show raw response with inputs for debugging
       const debugInfo = {
         inputs: {
           address,
           payloadHex,
           originalMessage: message,
-          encodingType
+          encodingType,
         },
-        response: signDataResponse
+        response: signDataResponse,
       }
       const rawResponseString = JSON.stringify(debugInfo, null, 2)
       onRawResponse(rawResponseString)

--- a/src/components/cards/signDataCard.js
+++ b/src/components/cards/signDataCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React, {useState} from 'react'
 import ApiCardWithModal from './apiCardWithModal'
 import {Buffer} from 'buffer'
@@ -57,7 +58,7 @@ const SignDataCard = ({api, onRawResponse, onResponse, onWaiting}) => {
       const payloadHex = getPayloadHex(message, encodingType)
       
       // Log the inputs for debugging
-      console.log('SignData inputs:', { address, payloadHex, originalMessage: message, encodingType })
+      logger.log('SignData inputs:', { address, payloadHex, originalMessage: message, encodingType })
       
       const signDataResponse = await api?.signData(address, payloadHex)
       
@@ -81,7 +82,7 @@ const SignDataCard = ({api, onRawResponse, onResponse, onWaiting}) => {
       } else {
         onResponse(error)
       }
-      console.error(error)
+      logger.error(error)
     } finally {
       onWaiting(false)
     }

--- a/src/components/cards/signTransactionCard.js
+++ b/src/components/cards/signTransactionCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React, {useState} from 'react'
 import {bytesToHex, hexToBytes} from '../../utils/utils'
 import {
@@ -46,7 +47,7 @@ const SignTransactionCard = ({api, onRawResponse, onResponse, onWaiting}) => {
     if (!txHex) {
       txHex = await buildTransaction(defaultValue)
     }
-    console.log('[SignTransactionCard] Unsingned Tx:', txHex)
+    logger.log('[SignTransactionCard] Unsingned Tx:', txHex)
     api
       ?.signTx(txHex, partialSign)
       .then((witnessHex) => {
@@ -69,7 +70,7 @@ const SignTransactionCard = ({api, onRawResponse, onResponse, onWaiting}) => {
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.log(e)
+        logger.log(e)
       })
   }
   const apiProps = {

--- a/src/components/cards/signTransactionCard.js
+++ b/src/components/cards/signTransactionCard.js
@@ -62,10 +62,7 @@ const SignTransactionCard = ({api, onRawResponse, onResponse, onWaiting}) => {
             signedTx.add_vkey_witness(walletVkeys.get(i))
           }
         }
-        onResponse(
-          JSON.stringify({signedTx: signedTx.to_hex(), witness: witnessHex}, undefined, 2),
-          false,
-        )
+        onResponse(JSON.stringify({signedTx: signedTx.to_hex(), witness: witnessHex}, undefined, 2), false)
       })
       .catch((e) => {
         onWaiting(false)

--- a/src/components/cards/signTransactionCard.js
+++ b/src/components/cards/signTransactionCard.js
@@ -12,7 +12,8 @@ import {
   getAddressFromBech32,
 } from '../../utils/cslTools'
 import ApiCardWithModal from './apiCardWithModal'
-import {CommonStyles, ModalWindowContent} from '../ui-constants'
+import {ModalWindowContent} from '../ui-constants'
+import InputWithLabel from '../inputWithLabel'
 
 const SignTransactionCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   const defaultValue = {amount: '2000000', address: ''}
@@ -81,16 +82,11 @@ const SignTransactionCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   return (
     <ApiCardWithModal {...apiProps}>
       <div className={ModalWindowContent.contentPadding}>
-        <label htmlFor="txHex" className={ModalWindowContent.contentLabelStyle}>
-          Unsigned Transaction Hex
-        </label>
-        <input
-          type="text"
-          id="txHex"
-          className={CommonStyles.inputStyles}
-          placeholder=""
-          value={signTransactionInput}
-          onChange={(event) => setSignTransactionInput(event.target.value)}
+        <InputWithLabel
+          inputName="Unsigned Transaction Hex"
+          inputValue={signTransactionInput}
+          onChangeFunction={(event) => setSignTransactionInput(event.target.value)}
+          wrapperClassName=""
         />
         <label htmlFor="partialSign" className={ModalWindowContent.contentLabelStyle}>
           Partially Sign Transaction?

--- a/src/components/cards/staking/withdrawCard.js
+++ b/src/components/cards/staking/withdrawCard.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import {
   getAddressFromBytes,
   getCertificateBuilder,
@@ -75,7 +76,7 @@ const WithdrawCard = ({api, onRawResponse, onResponse, onWaiting}) => {
       setShowSuccessInfo(true)
     } catch (error) {
       setErrorMessage('Network error occurred while fetching account info')
-      console.error(error)
+      logger.error(error)
     } finally {
       setWaitingAccountInfo(false)
     }
@@ -108,7 +109,7 @@ const WithdrawCard = ({api, onRawResponse, onResponse, onWaiting}) => {
       const tx = txBuilderWithWithdrawal.build_tx()
 
       const fixedTx = getFixedTxFromBytes(tx.to_bytes())
-      console.log('[WithdrawCard] Unsingned Tx:', fixedTx)
+      logger.log('[WithdrawCard] Unsingned Tx:', fixedTx)
       const signaturesWitnessesSet = await api.signTx(fixedTx.to_hex())
 
       const witnesses = getTransactionWitnessSetFromBytes(signaturesWitnessesSet)
@@ -116,14 +117,14 @@ const WithdrawCard = ({api, onRawResponse, onResponse, onWaiting}) => {
       for (let i = 0; i < vkeysSignatures.len(); i++) {
         fixedTx.add_vkey_witness(vkeysSignatures.get(i))
       }
-      console.log('Withdrawal signed Tx: ', fixedTx.to_hex())
+      logger.log('Withdrawal signed Tx: ', fixedTx.to_hex())
 
       const txId = await api?.submitTx(fixedTx.to_hex())
       onWaiting(false)
       onRawResponse(txId)
       onResponse(txId, false)
     } catch (error) {
-      console.error(error)
+      logger.error(error)
       onRawResponse('')
       onResponse(error)
     } finally {

--- a/src/components/cards/staking/withdrawCard.js
+++ b/src/components/cards/staking/withdrawCard.js
@@ -89,7 +89,9 @@ const WithdrawCard = ({api, onRawResponse, onResponse, onWaiting}) => {
       const pubStakeKey = await api?.cip95.getRegisteredPubStakeKeys()
       const stakeKeyHash = getPublicKeyFromHex(
         firstOrThrow(pubStakeKey, 'No registered stake key available from wallet'),
-      ).hash().to_hex()
+      )
+        .hash()
+        .to_hex()
       const txBuilderWithWithdrawal = await getTxBuilderWithWithdrawal(stakeKeyHash, networkType, rewardAmount)
       const utxos = await api?.getUtxos()
 

--- a/src/components/cards/submitTransactionCard.js
+++ b/src/components/cards/submitTransactionCard.js
@@ -1,6 +1,7 @@
 import React, {useState} from 'react'
 import ApiCardWithModal from './apiCardWithModal'
-import {CommonStyles, ModalWindowContent} from '../ui-constants'
+import {ModalWindowContent} from '../ui-constants'
+import InputWithLabel from '../inputWithLabel'
 import runApiCall from '../../utils/runApiCall'
 
 const SubmitTransactionCard = ({api, onRawResponse, onResponse, onWaiting}) => {
@@ -17,16 +18,11 @@ const SubmitTransactionCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   return (
     <ApiCardWithModal {...apiProps}>
       <div className={ModalWindowContent.contentPadding}>
-        <label htmlFor="txHex" className={ModalWindowContent.contentLabelStyle}>
-          Signed Tx Hex
-        </label>
-        <input
-          type="text"
-          id="txHex"
-          className={CommonStyles.inputStyles}
-          placeholder=""
-          value={submitTransactionInput}
-          onChange={(event) => setSubmitTransactionInput(event.target.value)}
+        <InputWithLabel
+          inputName="Signed Tx Hex"
+          inputValue={submitTransactionInput}
+          onChangeFunction={(event) => setSubmitTransactionInput(event.target.value)}
+          wrapperClassName=""
         />
       </div>
     </ApiCardWithModal>

--- a/src/components/cards/submitTransactionCard.js
+++ b/src/components/cards/submitTransactionCard.js
@@ -1,3 +1,4 @@
+import logger from '../../utils/logger'
 import React, {useState} from 'react'
 import ApiCardWithModal from './apiCardWithModal'
 import {CommonStyles, ModalWindowContent} from '../ui-constants'
@@ -18,7 +19,7 @@ const SubmitTransactionCard = ({api, onRawResponse, onResponse, onWaiting}) => {
         onWaiting(false)
         onRawResponse('')
         onResponse(e)
-        console.log(e)
+        logger.log(e)
       })
   }
 

--- a/src/components/cards/submitTransactionCard.js
+++ b/src/components/cards/submitTransactionCard.js
@@ -1,27 +1,13 @@
-import logger from '../../utils/logger'
 import React, {useState} from 'react'
 import ApiCardWithModal from './apiCardWithModal'
 import {CommonStyles, ModalWindowContent} from '../ui-constants'
+import runApiCall from '../../utils/runApiCall'
 
 const SubmitTransactionCard = ({api, onRawResponse, onResponse, onWaiting}) => {
   const [submitTransactionInput, setSubmitTransactionInput] = useState('')
 
-  const submitTransactionClick = () => {
-    onWaiting(true)
-    api
-      ?.submitTx(submitTransactionInput)
-      .then((txId) => {
-        onWaiting(false)
-        onRawResponse(txId)
-        onResponse(txId, false)
-      })
-      .catch((e) => {
-        onWaiting(false)
-        onRawResponse('')
-        onResponse(e)
-        logger.log(e)
-      })
-  }
+  const submitTransactionClick = () =>
+    runApiCall(() => api.submitTx(submitTransactionInput), {onRawResponse, onResponse, onWaiting}, {stringify: false})
 
   const apiProps = {
     buttonLabel: 'submitTx',

--- a/src/components/checkboxWithLabel.js
+++ b/src/components/checkboxWithLabel.js
@@ -1,25 +1,25 @@
 import React from 'react'
 
 const CheckboxWithLabel = (props) => {
-    const {currentState, onChangeFunc, name, labelText, disabled} = props
+  const {currentState, onChangeFunc, name, labelText, disabled} = props
 
-    return (
-        <div className={`text-l tracking-tight text-gray-300 mt-5 ${disabled ? 'opacity-50' : ''}`}>
-        <div>
-          <input
-            type="checkbox"
-            id={name + "Id"}
-            name={name}
-            checked={currentState}
-            onChange={onChangeFunc}
-            disabled={disabled}
-          />
-          <label htmlFor={name + "Id"} className={`font-bold ${disabled ? 'cursor-not-allowed' : ''}`}>
-            <span /> {labelText}
-          </label>
-        </div>
+  return (
+    <div className={`text-l tracking-tight text-gray-300 mt-5 ${disabled ? 'opacity-50' : ''}`}>
+      <div>
+        <input
+          type="checkbox"
+          id={name + 'Id'}
+          name={name}
+          checked={currentState}
+          onChange={onChangeFunc}
+          disabled={disabled}
+        />
+        <label htmlFor={name + 'Id'} className={`font-bold ${disabled ? 'cursor-not-allowed' : ''}`}>
+          <span /> {labelText}
+        </label>
       </div>
-    )
+    </div>
+  )
 }
 
 export default CheckboxWithLabel

--- a/src/components/ethereumAccessButton.js
+++ b/src/components/ethereumAccessButton.js
@@ -2,6 +2,7 @@ import React from 'react'
 import useEthereum from '../hooks/ethereumProvider'
 import {IN_PROGRESS, NO_PROVIDER} from '../utils/connectionStates'
 import {shortAddress, chainName} from '../utils/ethereumUtils'
+import AccessButtonShell from './accessButtonShell'
 
 const EthereumAccessButton = () => {
   const {accounts, connectionState, connect, chainId} = useEthereum()
@@ -9,48 +10,42 @@ const EthereumAccessButton = () => {
 
   if (isConnected) {
     return (
-      <div className="mx-auto bg-gray-900">
-        <div className="grid justify-items-center py-3">
-          <div className="text-xl font-bold tracking-tight text-white text-center">
-            <div className="py-5">
-              <div>Connected to Ethereum Wallet</div>
-              <div className="py-1 text-purple-400">{shortAddress(accounts[0])}</div>
-              {chainId && (
-                <div className="py-1">
-                  <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-purple-900 text-purple-300 border border-purple-700">
-                    {chainName(chainId)}
-                  </span>
-                </div>
-              )}
-            </div>
+      <AccessButtonShell>
+        <div className="text-xl font-bold tracking-tight text-white text-center">
+          <div className="py-5">
+            <div>Connected to Ethereum Wallet</div>
+            <div className="py-1 text-purple-400">{shortAddress(accounts[0])}</div>
+            {chainId && (
+              <div className="py-1">
+                <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-purple-900 text-purple-300 border border-purple-700">
+                  {chainName(chainId)}
+                </span>
+              </div>
+            )}
           </div>
         </div>
-      </div>
+      </AccessButtonShell>
     )
   }
 
   if (connectionState === IN_PROGRESS) {
     return (
-      <div className="mx-auto bg-gray-900">
-        <div className="grid justify-items-center pt-5 pb-5 text-m font-bold tracking-tight text-green-500">
-          <label>Connecting to Ethereum wallet...</label>
-        </div>
-      </div>
+      <AccessButtonShell innerClassName="grid justify-items-center pt-5 pb-5 text-m font-bold tracking-tight text-green-500">
+        <label>Connecting to Ethereum wallet...</label>
+      </AccessButtonShell>
     )
   }
 
   return (
-    <div className="mx-auto bg-gray-900">
-      <div className="grid justify-items-center py-3">
-        <button
-          className="rounded-md bg-purple-600 hover:bg-purple-400 active:bg-purple-800 py-5 px-5 disabled:opacity-50 text-white font-semibold"
-          disabled={connectionState === NO_PROVIDER}
-          onClick={connect}
-        >
-          {connectionState === NO_PROVIDER ? 'No Ethereum Wallet Found' : 'Connect Ethereum Wallet'}
-        </button>
-      </div>
-    </div>
+    <AccessButtonShell>
+      <button
+        className="rounded-md bg-purple-600 hover:bg-purple-400 active:bg-purple-800 py-5 px-5 disabled:opacity-50 text-white font-semibold"
+        disabled={connectionState === NO_PROVIDER}
+        onClick={connect}
+      >
+        {connectionState === NO_PROVIDER ? 'No Ethereum Wallet Found' : 'Connect Ethereum Wallet'}
+      </button>
+    </AccessButtonShell>
   )
 }
 

--- a/src/components/inputWithLabel.js
+++ b/src/components/inputWithLabel.js
@@ -2,23 +2,28 @@ import React from 'react'
 import {CommonStyles, ModalWindowContent} from './ui-constants'
 
 const InputWithLabel = (props) => {
-  const {inputName, inputValue, onChangeFunction, helpText, type} = props
+  const {inputName, inputValue, onChangeFunction, helpText, type, placeholder, min, step, wrapperClassName, disabled} =
+    props
 
   const inputType = type || 'text'
 
   const inputID = inputName.split(' ').join('')
 
   return (
-    <div className="mt-3">
+    <div className={wrapperClassName ?? 'mt-3'}>
       <label htmlFor={'input-' + inputID} className={ModalWindowContent.contentLabelStyle}>
         {inputName}
       </label>
       <input
         type={inputType}
         id={'input-' + inputID}
-        className={CommonStyles.inputStyles}
+        className={disabled ? CommonStyles.inputStylesDisabled : CommonStyles.inputStyles}
+        placeholder={placeholder}
+        min={min}
+        step={step}
         value={inputValue}
         onChange={onChangeFunction}
+        disabled={disabled}
       />
       {helpText ? (
         <label htmlFor={'input-' + inputID} className="block mb-1 ml-1 text-sm font-light text-gray-300">

--- a/src/components/networkToggle.js
+++ b/src/components/networkToggle.js
@@ -12,9 +12,7 @@ const NetworkToggle = () => {
         <button
           onClick={() => setActiveNetwork(NETWORK_CARDANO)}
           className={`text-xs sm:text-sm font-semibold px-3 py-1 rounded-md transition-colors duration-200 ${
-            activeNetwork === NETWORK_CARDANO
-              ? 'bg-blue-600 text-white'
-              : 'text-gray-400 hover:text-blue-400'
+            activeNetwork === NETWORK_CARDANO ? 'bg-blue-600 text-white' : 'text-gray-400 hover:text-blue-400'
           }`}
         >
           Cardano
@@ -22,9 +20,7 @@ const NetworkToggle = () => {
         <button
           onClick={() => setActiveNetwork(NETWORK_ETHEREUM)}
           className={`text-xs sm:text-sm font-semibold px-3 py-1 rounded-md transition-colors duration-200 ${
-            activeNetwork === NETWORK_ETHEREUM
-              ? 'bg-purple-600 text-white'
-              : 'text-gray-400 hover:text-purple-400'
+            activeNetwork === NETWORK_ETHEREUM ? 'bg-purple-600 text-white' : 'text-gray-400 hover:text-purple-400'
           }`}
         >
           Ethereum

--- a/src/components/tabs/bitcoinMainTab.js
+++ b/src/components/tabs/bitcoinMainTab.js
@@ -1,13 +1,8 @@
-import React from 'react'
+import {NO_PROVIDER} from '../../utils/connectionStates'
+import ChainStatusMessage from './chainStatusMessage'
 
-const BitcoinMainTab = () => {
-  return (
-    <div className="bg-gray-900 grid justify-items-center pt-5">
-      <div className="text-m font-bold tracking-tight text-white">
-        <label>Bitcoin support coming soon</label>
-      </div>
-    </div>
-  )
-}
+const BitcoinMainTab = () => (
+  <ChainStatusMessage connectionState={NO_PROVIDER} notFoundText="Bitcoin support coming soon" />
+)
 
 export default BitcoinMainTab

--- a/src/components/tabs/chainStatusMessage.js
+++ b/src/components/tabs/chainStatusMessage.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import {CONNECTED, NO_PROVIDER} from '../../utils/connectionStates'
+
+// Shared connection-status banner for each chain's main tab. Each chain passes
+// its own wording; connectedContent (default none) shows when connected.
+const ChainStatusMessage = ({connectionState, notFoundText, notConnectedText, connectedContent = null}) => {
+  const message = () => {
+    if (connectionState === CONNECTED) return connectedContent
+    if (connectionState === NO_PROVIDER) return notFoundText
+    return notConnectedText
+  }
+
+  return (
+    <div className="bg-gray-900 grid justify-items-center pt-5">
+      <div className="text-m font-bold tracking-tight text-white">{message()}</div>
+    </div>
+  )
+}
+
+export default ChainStatusMessage

--- a/src/components/tabs/ethereumMainTab.js
+++ b/src/components/tabs/ethereumMainTab.js
@@ -1,21 +1,15 @@
 import useEthereum from '../../hooks/ethereumProvider'
-import {CONNECTED, NO_PROVIDER} from '../../utils/connectionStates'
+import ChainStatusMessage from './chainStatusMessage'
 
 const EthereumMainTab = () => {
   const {connectionState} = useEthereum()
 
-  const message = () => {
-    if (connectionState === CONNECTED) return null
-    if (connectionState === NO_PROVIDER) {
-      return <label>No Ethereum wallet found. Please install a compatible Ethereum wallet.</label>
-    }
-    return <label>Ethereum wallet is not connected</label>
-  }
-
   return (
-    <div className="bg-gray-900 grid justify-items-center pt-5">
-      <div className="text-m font-bold tracking-tight text-white">{message()}</div>
-    </div>
+    <ChainStatusMessage
+      connectionState={connectionState}
+      notFoundText="No Ethereum wallet found. Please install a compatible Ethereum wallet."
+      notConnectedText="Ethereum wallet is not connected"
+    />
   )
 }
 

--- a/src/components/tabs/mainTab.js
+++ b/src/components/tabs/mainTab.js
@@ -1,28 +1,15 @@
-const MainTab = (props) => {
-  const {isWalletConnected, isNoProvider} = props
+import {CONNECTED, NO_PROVIDER, NOT_CONNECTED} from '../../utils/connectionStates'
+import ChainStatusMessage from './chainStatusMessage'
 
-  const walletConnectionMessage = () => {
-    if (!isWalletConnected) {
-      if (isNoProvider) {
-        return (
-          <div className="text-m font-bold tracking-tight text-white">
-            <label>Cardano wallet is not found</label>
-          </div>
-        )
-      } else {
-        return (
-          <div className="text-m font-bold tracking-tight text-white">
-            <label>Wallet is not connected</label>
-          </div>
-        )
-      }
-    }
-  }
+const MainTab = ({isWalletConnected, isNoProvider}) => {
+  const connectionState = isWalletConnected ? CONNECTED : isNoProvider ? NO_PROVIDER : NOT_CONNECTED
 
   return (
-    <>
-      <div className="bg-gray-900 grid justify-items-center pt-5">{walletConnectionMessage()}</div>
-    </>
+    <ChainStatusMessage
+      connectionState={connectionState}
+      notFoundText="Cardano wallet is not found"
+      notConnectedText="Wallet is not connected"
+    />
   )
 }
 

--- a/src/components/tabs/subtabs/NFTTab.js
+++ b/src/components/tabs/subtabs/NFTTab.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import {useState} from 'react'
 import {Buffer} from 'buffer'
 import useCardano from '../../../hooks/cardanoProvider'
@@ -77,7 +78,7 @@ const NFTTab = () => {
 
   const handleNFTsAmount = () => {
     setIsMoreThenOneNFT(!isMoreThenOneNFT)
-    console.debug(`[NFTTab] mint MoreThenOneNFT is set: ${!isMoreThenOneNFT}`)
+    logger.debug(`[NFTTab] mint MoreThenOneNFT is set: ${!isMoreThenOneNFT}`)
     if (isMoreThenOneNFT === false) {
       setCurrentNFTsAmount(1)
     }
@@ -85,10 +86,10 @@ const NFTTab = () => {
 
   const handleNftVersionOnChange = () => {
     setIsV2nft(!isV2nft)
-    console.debug(`[NFTTab] V2 is set: ${!isV2nft}`)
+    logger.debug(`[NFTTab] V2 is set: ${!isV2nft}`)
     setCurrentMintingInfo(emptyTokenInfo)
     setMintingTxInfo([])
-    console.debug('[NFTTab] cleared the metadata and the prepared minting batch info')
+    logger.debug('[NFTTab] cleared the metadata and the prepared minting batch info')
   }
 
   const handleImageTypeChange = (event) => {
@@ -96,7 +97,7 @@ const NFTTab = () => {
   }
 
   const sliceBy64Char = (inputString) => {
-    console.debug(`[NFTTab] inputString: ${JSON.stringify(inputString)}`)
+    logger.debug(`[NFTTab] inputString: ${JSON.stringify(inputString)}`)
     if (inputString.length <= 64) {
       return inputString
     }
@@ -116,7 +117,7 @@ const NFTTab = () => {
   }
 
   const _genMeta = (nftName, nftImageUrl, nftDescription) => {
-    console.debug(
+    logger.debug(
       `[NFTTab][_genMeta]\nnftName: ${nftName}\nnftImageUrl: ${nftImageUrl}\nnftDescription: ${nftDescription}`,
     )
     const name = nftName.replace(/ /g, '_')
@@ -129,7 +130,7 @@ const NFTTab = () => {
     newInfo.metadata.image = imageUrl
     newInfo.metadata.files[0].src = imageUrl
     newInfo.metadata.description = description
-    console.debug(`[NFTTab][_genMeta] newInfo: ${JSON.stringify(newInfo, null, 2)}`)
+    logger.debug(`[NFTTab][_genMeta] newInfo: ${JSON.stringify(newInfo, null, 2)}`)
 
     return newInfo
   }
@@ -145,7 +146,7 @@ const NFTTab = () => {
   }
 
   const generateSeveralMetadata = () => {
-    console.debug(`[NFTTab][generateSeveralMetadata] ${currentNFTsAmount} NFTs metadata will be generated`)
+    logger.debug(`[NFTTab][generateSeveralMetadata] ${currentNFTsAmount} NFTs metadata will be generated`)
     const allMetadataInfo = []
     for (let index = 1; index <= currentNFTsAmount; index++) {
       const newName = currentNFTName + `_${index}`
@@ -162,7 +163,7 @@ const NFTTab = () => {
       const txBuilder = getTxBuilder()
 
       const changeAddress = await api?.getChangeAddress()
-      console.debug(`[NFTTab][mint] changeAddress -> ${changeAddress}`)
+      logger.debug(`[NFTTab][mint] changeAddress -> ${changeAddress}`)
       const wasmChangeAddress = getAddressFromBytes(changeAddress)
       const usedAddresses = await api?.getUsedAddresses()
       const usedAddress = getAddressFromBytes(firstOrThrow(usedAddresses, 'No used address available from wallet'))
@@ -175,7 +176,7 @@ const NFTTab = () => {
       for (const assetInfo of mintingTxInfo) {
         metadata[scriptHashHex][assetInfo.NFTName] = assetInfo.metadata
         metadata['version'] = isV2nft ? '2.0' : '1.0'
-        console.debug(`[NFTTab][mint] metadata -> ${JSON.stringify(metadata)}`)
+        logger.debug(`[NFTTab][mint] metadata -> ${JSON.stringify(metadata)}`)
         txBuilder.add_json_metadatum(strToBigNum('721'), JSON.stringify(metadata))
         txBuilder.add_mint_asset_and_output_min_required_coin(
           wasmNativeScript,
@@ -185,21 +186,21 @@ const NFTTab = () => {
         )
       }
 
-      console.debug(`[NFTTab][mint] getting UTxOs`)
+      logger.debug(`[NFTTab][mint] getting UTxOs`)
       const hexInputUtxos = await api?.getUtxos()
 
-      console.debug(`[NFTTab][mint] preparing wasmUTxOs`)
+      logger.debug(`[NFTTab][mint] preparing wasmUTxOs`)
       const wasmUtxos = getCslUtxos(hexInputUtxos)
 
-      console.debug(`[NFTTab][mint] adding inputs`)
+      logger.debug(`[NFTTab][mint] adding inputs`)
       txBuilder.add_inputs_from(wasmUtxos, getLargestFirstMultiAsset())
       txBuilder.add_required_signer(pubkeyHash)
       txBuilder.add_change_if_needed(wasmChangeAddress)
 
       const wasmUnsignedTransaction = txBuilder.build_tx()
       const fixedTx = getFixedTxFromBytes(wasmUnsignedTransaction.to_bytes())
-      console.log('[NFTTab][mint] Unsigned Tx:', fixedTx.to_hex())
-      console.debug(`[NFTTab][mint] signing the tx`)
+      logger.log('[NFTTab][mint] Unsigned Tx:', fixedTx.to_hex())
+      logger.debug(`[NFTTab][mint] signing the tx`)
       const witnessHex = await api?.signTx(fixedTx.to_hex())
       const wasmWitnessSet = getTransactionWitnessSetFromBytes(witnessHex)
       const vkeys = wasmWitnessSet.vkeys()
@@ -207,12 +208,12 @@ const NFTTab = () => {
         fixedTx.add_vkey_witness(vkeys.get(i))
       }
       const signedTxHex = fixedTx.to_hex()
-      console.log('[NFTTab][mint] Signed Tx:', signedTxHex)
+      logger.log('[NFTTab][mint] Signed Tx:', signedTxHex)
       const txId = await api?.submitTx(signedTxHex)
-      console.log(`[NFTTab][mint] Transaction successfully submitted: ${txId}`)
+      logger.log(`[NFTTab][mint] Transaction successfully submitted: ${txId}`)
     } catch (error) {
       handleError()
-      console.error(error)
+      logger.error(error)
     }
   }
 

--- a/src/components/tabs/subtabs/NFTTab.js
+++ b/src/components/tabs/subtabs/NFTTab.js
@@ -1,6 +1,6 @@
 import {useState} from 'react'
 import {Buffer} from 'buffer'
-import useYoroi from '../../../hooks/yoroiProvider'
+import useCardano from '../../../hooks/cardanoProvider'
 import {
   getAddressFromBytes,
   getAssetName,
@@ -39,7 +39,7 @@ const NFTTab = () => {
     {label: 'Video_WebM', value: 'video/webm'},
     {label: 'Video_WMV', value: 'video/x-ms-wmv'},
   ]
-  const {api, connectionState} = useYoroi()
+  const {api, connectionState} = useCardano()
   const [currentNFTName, setCurrentNFTName] = useState('')
   const [currentImageUrl, setCurrentImageUrl] = useState('')
   const [currentDescription, setCurrentDescription] = useState('')

--- a/src/components/tabs/subtabs/NFTTab.js
+++ b/src/components/tabs/subtabs/NFTTab.js
@@ -230,8 +230,8 @@ const NFTTab = () => {
                   Note: Currently the functionality of this is extremely limited, it is really only here to mint really
                   basic NFTs for testing.
                   <p />
-                  The minting policy is hardcoded to basically just use the pubkeyhash of your first used address, so all
-                  the NFTs you mint here will have the same policy id.
+                  The minting policy is hardcoded to basically just use the pubkeyhash of your first used address, so
+                  all the NFTs you mint here will have the same policy id.
                   <p />
                   They're not even really NFTs, cuz you can mint multiple of them. This is a work in progress and will
                   have more functionalities in the future.

--- a/src/components/tabs/subtabs/NFTTab.js
+++ b/src/components/tabs/subtabs/NFTTab.js
@@ -17,6 +17,7 @@ import {
   toInt,
 } from '../../../utils/cslTools'
 import {CONNECTED} from '../../../utils/connectionStates'
+import {chunkMessageTo64Bytes} from '../../../utils/utils'
 import {firstOrThrow} from '../../../utils/helpFunctions'
 import SelectWithLabel from '../../selectWithLabel'
 import InputWithLabel from '../../inputWithLabel'
@@ -96,18 +97,12 @@ const NFTTab = () => {
     setImageType(event.target.value)
   }
 
+  // CIP-25 stores a field as a plain string when it fits in one 64-byte chunk,
+  // or an array of <=64-byte chunks when longer. Chunking is byte-based (shared
+  // util) so multibyte characters are never split mid-sequence.
   const sliceBy64Char = (inputString) => {
-    logger.debug(`[NFTTab] inputString: ${JSON.stringify(inputString)}`)
-    if (inputString.length <= 64) {
-      return inputString
-    }
-    const step = 64
-    const resultArray = []
-    for (let startIndex = 0; startIndex < inputString.length; startIndex = startIndex + step) {
-      const stringSlice = inputString.slice(startIndex, startIndex + step)
-      resultArray.push(stringSlice)
-    }
-    return resultArray
+    const chunks = chunkMessageTo64Bytes(inputString)
+    return chunks.length <= 1 ? inputString : chunks
   }
 
   const clearInfo = () => {

--- a/src/components/tabs/subtabs/certificatesInTxPart.js
+++ b/src/components/tabs/subtabs/certificatesInTxPart.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import React from 'react'
 import ExpandablePanel from '../../expandablePanel'
 import {iconCollapsed16, iconExpanded16} from '../../ui-constants'
@@ -19,7 +20,7 @@ const CertificatesInTxPart = ({getters}) => {
     }
     if (votesInTx) {
       const voteJsonObjects = JSON.parse(votesInTx)
-      console.log('voteJsonObjects', voteJsonObjects)
+      logger.log('voteJsonObjects', voteJsonObjects)
       for (const voteJsonObject of voteJsonObjects) {
         resultArray.push(['Votes', voteJsonObject])
       }

--- a/src/components/tabs/subtabs/cip20Tab.js
+++ b/src/components/tabs/subtabs/cip20Tab.js
@@ -369,7 +369,13 @@ const Cip20Tab = () => {
               onClose={() => setPickerOpen(false)}
               modal
               overlayStyle={{background: 'rgba(0,0,0,0.75)'}}
-              contentStyle={{width: 'min(90vw, 640px)', maxHeight: '90vh', overflowY: 'auto', border: 'none', padding: 0}}
+              contentStyle={{
+                width: 'min(90vw, 640px)',
+                maxHeight: '90vh',
+                overflowY: 'auto',
+                border: 'none',
+                padding: 0,
+              }}
             >
               <div className="bg-gray-900 border rounded-md border-gray-700 p-4 text-gray-300">
                 <div className="flex items-center justify-between mb-3">

--- a/src/components/tabs/subtabs/cip20Tab.js
+++ b/src/components/tabs/subtabs/cip20Tab.js
@@ -2,13 +2,12 @@ import React, {useState, useEffect, useMemo} from 'react'
 import Popup from 'reactjs-popup'
 import useCardano from '../../../hooks/cardanoProvider'
 import {CONNECTED} from '../../../utils/connectionStates'
-import {hexToBytes} from '../../../utils/utils'
+import {hexToBytes, chunkMessageTo64Bytes} from '../../../utils/utils'
 import {
   getUtxoFromHex,
   getAddressFromBech32,
   getFixedTxFromBytes,
   getTransactionWitnessSetFromBytes,
-  chunkMessageTo64Bytes,
   buildCip20Tx,
   compareLovelaceDesc,
 } from '../../../utils/cslTools'

--- a/src/components/tabs/subtabs/cip20Tab.js
+++ b/src/components/tabs/subtabs/cip20Tab.js
@@ -1,6 +1,6 @@
 import React, {useState, useEffect, useMemo} from 'react'
 import Popup from 'reactjs-popup'
-import useYoroi from '../../../hooks/yoroiProvider'
+import useCardano from '../../../hooks/cardanoProvider'
 import {CONNECTED} from '../../../utils/connectionStates'
 import {hexToBytes} from '../../../utils/utils'
 import {
@@ -55,7 +55,7 @@ const RawCborPopup = ({label, value}) => (
 )
 
 const Cip20Tab = () => {
-  const {api, connectionState} = useYoroi()
+  const {api, connectionState} = useCardano()
 
   const [hexUtxos, setHexUtxos] = useState([])
   const [decodedUtxos, setDecodedUtxos] = useState([])

--- a/src/components/tabs/subtabs/cip30Tab.js
+++ b/src/components/tabs/subtabs/cip30Tab.js
@@ -1,11 +1,11 @@
 import React, {useState} from 'react'
-import useYoroi from '../../../hooks/yoroiProvider'
+import useCardano from '../../../hooks/cardanoProvider'
 import ResponsesPart from './responsesPart'
 import OfficialPart from './officialPart'
 import {CONNECTED} from '../../../utils/connectionStates'
 
 const Cip30Tab = () => {
-  const {api, connectionState, selectedWallet} = useYoroi()
+  const {api, connectionState, selectedWallet} = useCardano()
   const [currentText, setCurrentText] = useState('')
   const [rawCurrentText, setRawCurrentText] = useState('')
   const [waiterState, setWaiterState] = useState(false)

--- a/src/components/tabs/subtabs/cip30Tab.js
+++ b/src/components/tabs/subtabs/cip30Tab.js
@@ -1,4 +1,5 @@
-import React, {useState} from 'react'
+import React from 'react'
+import useResponseState from '../../../hooks/useResponseState'
 import useCardano from '../../../hooks/cardanoProvider'
 import ResponsesPart from './responsesPart'
 import OfficialPart from './officialPart'
@@ -6,13 +7,7 @@ import {CONNECTED} from '../../../utils/connectionStates'
 
 const Cip30Tab = () => {
   const {api, connectionState, selectedWallet} = useCardano()
-  const [currentText, setCurrentText] = useState('')
-  const [rawCurrentText, setRawCurrentText] = useState('')
-  const [waiterState, setWaiterState] = useState(false)
-
-  const setResponse = (response, stringifyIt = true) => {
-    setCurrentText(stringifyIt ? JSON.stringify(response, undefined, 2) : response)
-  }
+  const {currentText, rawCurrentText, waiterState, setRawCurrentText, setWaiterState, setResponse} = useResponseState()
 
   return (
     <div className="py-5 px-5 text-gray-300">

--- a/src/components/tabs/subtabs/cip95AdditionalPart.js
+++ b/src/components/tabs/subtabs/cip95AdditionalPart.js
@@ -103,7 +103,7 @@ const Cip95AdditionalPart = ({api, onWaiting, onError, getters, setters}) => {
         setters={newSetters}
       />
       <div>
-        <CertificatesInTxPart getters={getters}/>
+        <CertificatesInTxPart getters={getters} />
       </div>
       <div className="block rounded-lg border mt-5 bg-gray-900 border-gray-700">
         <TabsComponent tabsData={data} />

--- a/src/components/tabs/subtabs/cip95AdditionalPart.js
+++ b/src/components/tabs/subtabs/cip95AdditionalPart.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import {useState} from 'react'
 import {getCertificateBuilder, getCslVotingBuilder} from '../../../utils/cslTools'
 import TabsComponent from '../tabsComponent'
@@ -20,14 +21,14 @@ const Cip95AdditionalPart = ({api, onWaiting, onError, getters, setters}) => {
     for (let i = 0; i < certs.len(); i++) {
       certsInJson.push(certs.get(i).to_json())
     }
-    console.log('CertInTx', certsInJson)
+    logger.log('CertInTx', certsInJson)
     setCertsInTx(certsInJson)
   }
 
   const handleAddingVotesInTx = (votingBuilderWithVote) => {
     setVotingBuilder(votingBuilderWithVote)
     setVotesInTx(votingBuilderWithVote.build().to_json())
-    console.log('Votes in Tx', votesInTx)
+    logger.log('Votes in Tx', votesInTx)
   }
 
   const getCertBuilder = () => {

--- a/src/components/tabs/subtabs/cip95Tab.js
+++ b/src/components/tabs/subtabs/cip95Tab.js
@@ -1,4 +1,5 @@
-import React, {useState} from 'react'
+import React from 'react'
+import useResponseState from '../../../hooks/useResponseState'
 import useCardano from '../../../hooks/cardanoProvider'
 import ResponsesPart from './responsesPart'
 import {CONNECTED} from '../../../utils/connectionStates'
@@ -6,13 +7,7 @@ import Cip95OfficialPart from './cip95OfficialPart'
 
 const Cip95Tab = () => {
   const {api, connectionState} = useCardano()
-  const [currentText, setCurrentText] = useState('')
-  const [rawCurrentText, setRawCurrentText] = useState('')
-  const [waiterState, setWaiterState] = useState(false)
-
-  const setResponse = (response, stringifyIt = true) => {
-    setCurrentText(stringifyIt ? JSON.stringify(response, undefined, 2) : response)
-  }
+  const {currentText, rawCurrentText, waiterState, setRawCurrentText, setWaiterState, setResponse} = useResponseState()
 
   return (
     <div className="py-5 px-5 text-gray-300">

--- a/src/components/tabs/subtabs/cip95Tab.js
+++ b/src/components/tabs/subtabs/cip95Tab.js
@@ -1,11 +1,11 @@
 import React, {useState} from 'react'
-import useYoroi from '../../../hooks/yoroiProvider'
+import useCardano from '../../../hooks/cardanoProvider'
 import ResponsesPart from './responsesPart'
 import {CONNECTED} from '../../../utils/connectionStates'
 import Cip95OfficialPart from './cip95OfficialPart'
 
 const Cip95Tab = () => {
-  const {api, connectionState} = useYoroi()
+  const {api, connectionState} = useCardano()
   const [currentText, setCurrentText] = useState('')
   const [rawCurrentText, setRawCurrentText] = useState('')
   const [waiterState, setWaiterState] = useState(false)

--- a/src/components/tabs/subtabs/cip95ToolsTab.js
+++ b/src/components/tabs/subtabs/cip95ToolsTab.js
@@ -1,12 +1,12 @@
 import {useState} from 'react'
-import useYoroi from '../../../hooks/yoroiProvider'
+import useCardano from '../../../hooks/cardanoProvider'
 import {CONNECTED} from '../../../utils/connectionStates'
 import Cip95AdditionalPart from './cip95AdditionalPart'
 import GetAllInfoCard from '../../cards/getAllInfoCard'
 import InfoPanel from './infoPanel'
 
 const Cip95TabTools = () => {
-  const {api, connectionState} = useYoroi()
+  const {api, connectionState} = useCardano()
   // Waiter label
   const [waiterState, setWaiterState] = useState(false)
   // Error label

--- a/src/components/tabs/subtabs/constitCommCertsTab.js
+++ b/src/components/tabs/subtabs/constitCommCertsTab.js
@@ -1,25 +1,10 @@
 import React from 'react'
 import TabsComponent from '../tabsComponent'
 import AuthCCPanel from '../../cards/govActions/authCCPanel'
-import {getCslCredentialFromBech32, getCslCredentialFromHex} from '../../../utils/cslTools'
+import {parseCredential} from '../../../utils/cslTools'
 
 const ConstitCommCertsTab = ({api, onWaiting, onError, getters, setters}) => {
-  const handleInputCreds = (input) => {
-    try {
-      return getCslCredentialFromHex(input)
-    } catch (err1) {
-      try {
-        return getCslCredentialFromBech32(input)
-      } catch (err2) {
-        // Throw instead of returning null so the caller's try/catch handles cleanup
-        // (onWaiting/onError), rather than feeding null into CSL and crashing
-        // with the opaque `expected instance of Fe`.
-        throw new Error(
-          `Invalid credential — not valid Hex or Bech32: ${JSON.stringify(err1)}, ${JSON.stringify(err2)}`,
-        )
-      }
-    }
-  }
+  const handleInputCreds = parseCredential
 
   const panelsProps = {
     api,

--- a/src/components/tabs/subtabs/eip1193Part.js
+++ b/src/components/tabs/subtabs/eip1193Part.js
@@ -14,10 +14,20 @@ const Eip1193Part = ({accounts, setRawCurrentText, setResponse, setWaiterState})
         <GetChainIdCard onRawResponse={setRawCurrentText} onResponse={setResponse} onWaiting={setWaiterState} />
       </div>
       <div>
-        <GetEthBalanceCard accounts={accounts} onRawResponse={setRawCurrentText} onResponse={setResponse} onWaiting={setWaiterState} />
+        <GetEthBalanceCard
+          accounts={accounts}
+          onRawResponse={setRawCurrentText}
+          onResponse={setResponse}
+          onWaiting={setWaiterState}
+        />
       </div>
       <div>
-        <SignEthMessageCard accounts={accounts} onRawResponse={setRawCurrentText} onResponse={setResponse} onWaiting={setWaiterState} />
+        <SignEthMessageCard
+          accounts={accounts}
+          onRawResponse={setRawCurrentText}
+          onResponse={setResponse}
+          onWaiting={setWaiterState}
+        />
       </div>
     </div>
   )

--- a/src/components/tabs/subtabs/eip1193Tab.js
+++ b/src/components/tabs/subtabs/eip1193Tab.js
@@ -1,4 +1,5 @@
-import React, {useState} from 'react'
+import React from 'react'
+import useResponseState from '../../../hooks/useResponseState'
 import useEthereum from '../../../hooks/ethereumProvider'
 import ResponsesPart from './responsesPart'
 import Eip1193Part from './eip1193Part'
@@ -6,13 +7,7 @@ import {CONNECTED} from '../../../utils/connectionStates'
 
 const Eip1193Tab = () => {
   const {accounts, connectionState} = useEthereum()
-  const [currentText, setCurrentText] = useState('')
-  const [rawCurrentText, setRawCurrentText] = useState('')
-  const [waiterState, setWaiterState] = useState(false)
-
-  const setResponse = (response, stringifyIt = true) => {
-    setCurrentText(stringifyIt ? JSON.stringify(response, undefined, 2) : response)
-  }
+  const {currentText, rawCurrentText, waiterState, setRawCurrentText, setWaiterState, setResponse} = useResponseState()
 
   return (
     <div className="py-5 px-5 text-gray-300">

--- a/src/components/tabs/subtabs/erc20Tab.js
+++ b/src/components/tabs/subtabs/erc20Tab.js
@@ -1,4 +1,5 @@
-import React, {useState} from 'react'
+import React from 'react'
+import useResponseState from '../../../hooks/useResponseState'
 import useEthereum from '../../../hooks/ethereumProvider'
 import ResponsesPart from './responsesPart'
 import GetErc20BalanceCard from '../../cards/ethereum/getErc20BalanceCard'
@@ -7,13 +8,7 @@ import {CONNECTED} from '../../../utils/connectionStates'
 
 const Erc20Tab = () => {
   const {accounts, connectionState} = useEthereum()
-  const [currentText, setCurrentText] = useState('')
-  const [rawCurrentText, setRawCurrentText] = useState('')
-  const [waiterState, setWaiterState] = useState(false)
-
-  const setResponse = (response, stringifyIt = true) => {
-    setCurrentText(stringifyIt ? JSON.stringify(response, undefined, 2) : response)
-  }
+  const {currentText, rawCurrentText, waiterState, setRawCurrentText, setWaiterState, setResponse} = useResponseState()
 
   return (
     <div className="py-5 px-5 text-gray-300">

--- a/src/components/tabs/subtabs/ethTransactionsTab.js
+++ b/src/components/tabs/subtabs/ethTransactionsTab.js
@@ -1,4 +1,5 @@
-import React, {useState} from 'react'
+import React from 'react'
+import useResponseState from '../../../hooks/useResponseState'
 import useEthereum from '../../../hooks/ethereumProvider'
 import ResponsesPart from './responsesPart'
 import SendEthTransactionCard from '../../cards/ethereum/sendEthTransactionCard'
@@ -6,13 +7,7 @@ import {CONNECTED} from '../../../utils/connectionStates'
 
 const EthTransactionsTab = () => {
   const {accounts, connectionState} = useEthereum()
-  const [currentText, setCurrentText] = useState('')
-  const [rawCurrentText, setRawCurrentText] = useState('')
-  const [waiterState, setWaiterState] = useState(false)
-
-  const setResponse = (response, stringifyIt = true) => {
-    setCurrentText(stringifyIt ? JSON.stringify(response, undefined, 2) : response)
-  }
+  const {currentText, rawCurrentText, waiterState, setRawCurrentText, setWaiterState, setResponse} = useResponseState()
 
   return (
     <div className="py-5 px-5 text-gray-300">

--- a/src/components/tabs/subtabs/govBasicFunctionsTab.js
+++ b/src/components/tabs/subtabs/govBasicFunctionsTab.js
@@ -7,6 +7,7 @@ import {
   getCslCredentialFromHex,
   getCslCredentialFromScriptFromBech32,
   getCslCredentialFromScriptFromHex,
+  parseCredential,
 } from '../../../utils/cslTools'
 import DRepRegistrationPanel from '../../cards/govActions/dRepRegistrationPanel'
 import DRepUpdatePanel from '../../cards/govActions/dRepUpdatePanel'
@@ -16,22 +17,7 @@ import RegisterStakeKeyPanel from '../../cards/govActions/regStakeKeyPanel'
 import UnregisterStakeKeyPanel from '../../cards/govActions/unregStakeKeyPanel'
 
 const GovBasicFunctionsTab = ({api, onWaiting, onError, getters, setters}) => {
-  const handleInputCreds = (input) => {
-    try {
-      return getCslCredentialFromHex(input)
-    } catch (err1) {
-      try {
-        return getCslCredentialFromBech32(input)
-      } catch (err2) {
-        // Throw instead of returning null so the caller's try/catch handles cleanup
-        // (onWaiting/onError), rather than feeding null into CSL and crashing
-        // with the opaque `expected instance of Fe`.
-        throw new Error(
-          `Invalid credential — not valid Hex or Bech32: ${JSON.stringify(err1)}, ${JSON.stringify(err2)}`,
-        )
-      }
-    }
-  }
+  const handleInputCreds = parseCredential
 
   /**
    *

--- a/src/components/tabs/subtabs/govBasicFunctionsTab.js
+++ b/src/components/tabs/subtabs/govBasicFunctionsTab.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import TabsComponent from '../tabsComponent'
 import VoteDelegationPanel from '../../cards/govActions/voteDelegationPanel'
 import {
@@ -92,7 +93,7 @@ const GovBasicFunctionsTab = ({api, onWaiting, onError, getters, setters}) => {
    */
   const handleDrepId = (bechEncodedID) => {
     if (!isValidDRepID(bechEncodedID) && !isPotentiallyValidHex(bechEncodedID)) {
-      console.error(`The value "${bechEncodedID}" is not valid dRepID`)
+      logger.error(`The value "${bechEncodedID}" is not valid dRepID`)
       onError()
       return
     }

--- a/src/components/tabs/subtabs/infoPanel.js
+++ b/src/components/tabs/subtabs/infoPanel.js
@@ -39,9 +39,7 @@ const InfoPanel = ({getters}) => {
         </div>
         <div>
           <span>Change address: </span>
-          <span className={spanProperties}>
-            {changeAddress.length > 0 ? changeAddress : '-'}
-          </span>
+          <span className={spanProperties}>{changeAddress.length > 0 ? changeAddress : '-'}</span>
         </div>
         <div>
           <span>Reward address: </span>

--- a/src/components/tabs/subtabs/officialPart.js
+++ b/src/components/tabs/subtabs/officialPart.js
@@ -18,7 +18,12 @@ const OfficialPart = ({api, setRawCurrentText, setResponse, setWaiterState, sele
   return (
     <div className="grid justify-items-stretch grid-cols-1 md:grid-cols-2 gap-2">
       <div>
-        <IsEnabledCard onRawResponse={setRawCurrentText} onResponse={setResponse} onWaiting={setWaiterState} selectedWallet={selectedWallet} />
+        <IsEnabledCard
+          onRawResponse={setRawCurrentText}
+          onResponse={setResponse}
+          onWaiting={setWaiterState}
+          selectedWallet={selectedWallet}
+        />
       </div>
       <div>
         <GetNetworkIdCard
@@ -77,12 +82,7 @@ const OfficialPart = ({api, setRawCurrentText, setResponse, setWaiterState, sele
         />
       </div>
       <div>
-        <GetUtxosCard
-          api={api}
-          onRawResponse={setRawCurrentText}
-          onResponse={setResponse}
-          onWaiting={setWaiterState}
-        />
+        <GetUtxosCard api={api} onRawResponse={setRawCurrentText} onResponse={setResponse} onWaiting={setWaiterState} />
       </div>
       <div>
         <GetCollateralUtxosCard

--- a/src/components/tabs/subtabs/responsesPart.js
+++ b/src/components/tabs/subtabs/responsesPart.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import React, {useState} from 'react'
 
 const ResponsesPart = ({rawCurrentText, currentText, currentWaiterState}) => {
@@ -7,12 +8,12 @@ const ResponsesPart = ({rawCurrentText, currentText, currentWaiterState}) => {
   const copyToClipboard = () => {
     navigator.clipboard.writeText(currentText).then(
       function () {
-        console.log('Async: Copying the processed response to clipboard was successful!')
+        logger.log('Async: Copying the processed response to clipboard was successful!')
         setMessageDisplayed(true)
         hideMessage()
       },
       function (err) {
-        console.error('Async: Could not copy text: ', err)
+        logger.error('Async: Could not copy text: ', err)
       },
     )
   }
@@ -20,12 +21,12 @@ const ResponsesPart = ({rawCurrentText, currentText, currentWaiterState}) => {
   const copyRawToClipboard = () => {
     navigator.clipboard.writeText(rawCurrentText).then(
       function () {
-        console.log('Async: Copying raw response to clipboard was successful!')
+        logger.log('Async: Copying raw response to clipboard was successful!')
         setMessageDisplayedRaw(true)
         hideMessageRaw()
       },
       function (err) {
-        console.error('Async: Could not copy raw response: ', err)
+        logger.error('Async: Could not copy raw response: ', err)
       },
     )
   }

--- a/src/components/tabs/subtabs/stakingTab.js
+++ b/src/components/tabs/subtabs/stakingTab.js
@@ -1,4 +1,4 @@
-import {useState} from 'react'
+import useResponseState from '../../../hooks/useResponseState'
 import useCardano from '../../../hooks/cardanoProvider'
 import {CONNECTED} from '../../../utils/connectionStates'
 import ResponsesPart from './responsesPart'
@@ -6,13 +6,7 @@ import WithdrawCard from '../../cards/staking/withdrawCard'
 
 const Staking = () => {
   const {api, connectionState} = useCardano()
-  const [currentText, setCurrentText] = useState('')
-  const [rawCurrentText, setRawCurrentText] = useState('')
-  const [waiterState, setWaiterState] = useState(false)
-
-  const setResponse = (response, stringifyIt = true) => {
-    setCurrentText(stringifyIt ? JSON.stringify(response, undefined, 2) : response)
-  }
+  const {currentText, rawCurrentText, waiterState, setRawCurrentText, setWaiterState, setResponse} = useResponseState()
   return (
     <div className="py-5 px-5 text-gray-300">
       {connectionState === CONNECTED ? (

--- a/src/components/tabs/subtabs/stakingTab.js
+++ b/src/components/tabs/subtabs/stakingTab.js
@@ -1,11 +1,11 @@
 import {useState} from 'react'
-import useYoroi from '../../../hooks/yoroiProvider'
+import useCardano from '../../../hooks/cardanoProvider'
 import {CONNECTED} from '../../../utils/connectionStates'
 import ResponsesPart from './responsesPart'
 import WithdrawCard from '../../cards/staking/withdrawCard'
 
 const Staking = () => {
-  const {api, connectionState} = useYoroi()
+  const {api, connectionState} = useCardano()
   const [currentText, setCurrentText] = useState('')
   const [rawCurrentText, setRawCurrentText] = useState('')
   const [waiterState, setWaiterState] = useState(false)

--- a/src/components/tabs/subtabs/testTxsTab.js
+++ b/src/components/tabs/subtabs/testTxsTab.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import React, {useState, useEffect} from 'react'
 import useCardano from '../../../hooks/cardanoProvider'
 import ResponsesPart from './responsesPart'
@@ -32,15 +33,15 @@ const TestTxsTab = () => {
       .then((addrs) => {
         if (addrs && addrs.length > 0) setWalletRewardAddrHex(addrs[0])
       })
-      .catch(console.error)
+      .catch(logger.error)
     api
       .getChangeAddress()
       .then((addr) => setWalletChangeAddrHex(addr))
-      .catch(console.error)
+      .catch(logger.error)
     api
       .getNetworkId()
       .then((id) => setNetworkId(id))
-      .catch(console.error)
+      .catch(logger.error)
   }, [api])
 
   const toggleFeature = (key) => {
@@ -105,7 +106,7 @@ const TestTxsTab = () => {
     } catch (e) {
       setRawCurrentText('')
       setCurrentText(`Sign error: ${e.message ?? JSON.stringify(e)}`)
-      console.error(e)
+      logger.error(e)
     }
     setWaiterState(false)
   }

--- a/src/components/tabs/subtabs/testTxsTab.js
+++ b/src/components/tabs/subtabs/testTxsTab.js
@@ -11,8 +11,7 @@ import {buildTestTx, FEATURE_GROUPS, CREDENTIAL_FEATURES} from '../../../utils/t
 const CRED_MODE_LABELS = {wallet: 'W', key: 'K', script: 'S'}
 const CRED_MODE_ORDER = ['wallet', 'key', 'script']
 
-const defaultCredModes = () =>
-  Object.fromEntries([...CREDENTIAL_FEATURES].map((f) => [f, 'key']))
+const defaultCredModes = () => Object.fromEntries([...CREDENTIAL_FEATURES].map((f) => [f, 'key']))
 
 const TestTxsTab = () => {
   const {api, connectionState} = useCardano()
@@ -93,13 +92,7 @@ const TestTxsTab = () => {
     }
     setWaiterState(true)
     try {
-      const {txHex} = buildTestTx(
-        enabledFeatures,
-        credModes,
-        walletRewardAddrHex,
-        walletChangeAddrHex,
-        networkId,
-      )
+      const {txHex} = buildTestTx(enabledFeatures, credModes, walletRewardAddrHex, walletChangeAddrHex, networkId)
       const witnessHex = await api.signTx(txHex, true)
       setRawCurrentText(witnessHex)
       setCurrentText(witnessHex)
@@ -121,13 +114,17 @@ const TestTxsTab = () => {
               <p className="font-semibold text-gray-200 text-sm mb-1">Credential mode (W / K / S)</p>
               <p className="text-gray-400 text-xs mb-2">
                 {'Shown next to cert/withdrawal features when enabled. Click to cycle: '}
-                <span className="text-orange-400 font-bold">W</span>{' = wallet stake addr  '}
-                <span className="text-orange-400 font-bold">K</span>{' = fake key hash  '}
-                <span className="text-orange-400 font-bold">S</span>{' = fake script hash'}
+                <span className="text-orange-400 font-bold">W</span>
+                {' = wallet stake addr  '}
+                <span className="text-orange-400 font-bold">K</span>
+                {' = fake key hash  '}
+                <span className="text-orange-400 font-bold">S</span>
+                {' = fake script hash'}
               </p>
               {walletRewardAddrHex ? (
                 <p className="text-gray-300 font-mono text-xs break-all">
-                  <span className="text-gray-400">Wallet stake: </span>{walletRewardAddrHex}
+                  <span className="text-gray-400">Wallet stake: </span>
+                  {walletRewardAddrHex}
                 </p>
               ) : (
                 <p className="text-gray-500 text-xs">Wallet stake address: not loaded</p>
@@ -151,7 +148,7 @@ const TestTxsTab = () => {
                     {group.features.map((feat) => {
                       const isCredFeat = CREDENTIAL_FEATURES.has(feat.key)
                       const isEnabled = enabledFeatures.has(feat.key)
-                      const mode = isCredFeat ? credModes[feat.key] ?? 'key' : null
+                      const mode = isCredFeat ? (credModes[feat.key] ?? 'key') : null
                       return (
                         <div key={feat.key} className="flex items-center justify-between">
                           <CheckboxWithLabel
@@ -195,11 +192,7 @@ const TestTxsTab = () => {
             </div>
           </div>
 
-          <ResponsesPart
-            rawCurrentText={rawCurrentText}
-            currentText={currentText}
-            currentWaiterState={waiterState}
-          />
+          <ResponsesPart rawCurrentText={rawCurrentText} currentText={currentText} currentWaiterState={waiterState} />
         </div>
       ) : (
         <div />

--- a/src/components/tabs/subtabs/testTxsTab.js
+++ b/src/components/tabs/subtabs/testTxsTab.js
@@ -1,5 +1,5 @@
 import React, {useState, useEffect} from 'react'
-import useYoroi from '../../../hooks/yoroiProvider'
+import useCardano from '../../../hooks/cardanoProvider'
 import ResponsesPart from './responsesPart'
 import CheckboxWithLabel from '../../checkboxWithLabel'
 import ExpandablePanel from '../../expandablePanel'
@@ -14,7 +14,7 @@ const defaultCredModes = () =>
   Object.fromEntries([...CREDENTIAL_FEATURES].map((f) => [f, 'key']))
 
 const TestTxsTab = () => {
-  const {api, connectionState} = useYoroi()
+  const {api, connectionState} = useCardano()
   const [enabledFeatures, setEnabledFeatures] = useState(new Set())
   const [credModes, setCredModes] = useState(defaultCredModes)
   const [walletRewardAddrHex, setWalletRewardAddrHex] = useState(null)

--- a/src/components/tabs/subtabs/tokenTab.js
+++ b/src/components/tabs/subtabs/tokenTab.js
@@ -133,7 +133,7 @@ const TokenTab = () => {
       txBuilder.add_inputs_from(wasmUtxos, getLargestFirstMultiAsset())
       txBuilder.add_required_signer(pubkeyHash)
       txBuilder.add_change_if_needed(wasmChangeAddress)
-      
+
       const wasmUnsignedTransaction = txBuilder.build_tx()
       const fixedTx = getFixedTxFromBytes(wasmUnsignedTransaction.to_bytes())
       logger.log('[TokenTab] Unsigned Tx:', fixedTx.to_hex())

--- a/src/components/tabs/subtabs/tokenTab.js
+++ b/src/components/tabs/subtabs/tokenTab.js
@@ -1,5 +1,5 @@
 import {useState} from 'react'
-import useYoroi from '../../../hooks/yoroiProvider'
+import useCardano from '../../../hooks/cardanoProvider'
 import {
   getAddressFromBytes,
   getAssetName,
@@ -18,7 +18,7 @@ import {firstOrThrow} from '../../../utils/helpFunctions'
 import InputWithLabel from '../../inputWithLabel'
 
 const TokenTab = () => {
-  const {api, connectionState} = useYoroi()
+  const {api, connectionState} = useCardano()
   const [currentTokenName, setCurrentTokenName] = useState('')
   const [currentTokenTicker, setCurrentTokenTicker] = useState('')
   const [currentTokenDescription, setCurrentTokenDescription] = useState('')

--- a/src/components/tabs/subtabs/tokenTab.js
+++ b/src/components/tabs/subtabs/tokenTab.js
@@ -1,3 +1,4 @@
+import logger from '../../../utils/logger'
 import {useState} from 'react'
 import useCardano from '../../../hooks/cardanoProvider'
 import {
@@ -84,13 +85,13 @@ const TokenTab = () => {
     const clearTokenName = currentTokenName.trim()
     if (clearTokenName.length === 0) {
       handleEmptyTokenName()
-      console.error("The token name shouldn't be empty")
+      logger.error("The token name shouldn't be empty")
       return
     }
 
     if (currentQuantity === '0') {
       handleEmptyTokenQuantity()
-      console.error("The token quantity isn't suitable")
+      logger.error("The token quantity isn't suitable")
       return
     }
     let quantityInt = 0
@@ -98,14 +99,14 @@ const TokenTab = () => {
       quantityInt = toInt(currentQuantity)
     } catch (error) {
       handleEmptyTokenQuantity()
-      console.error(error)
+      logger.error(error)
       return
     }
 
     const txBuilder = getTxBuilder()
 
     const changeAddress = await api?.getChangeAddress()
-    console.debug(`[dApp][Tokens_Tab][mint] changeAddress -> ${changeAddress}`)
+    logger.debug(`[dApp][Tokens_Tab][mint] changeAddress -> ${changeAddress}`)
 
     const wasmChangeAddress = getAddressFromBytes(changeAddress)
     try {
@@ -122,21 +123,21 @@ const TokenTab = () => {
         getTransactionOutputBuilder(wasmChangeAddress),
       )
 
-      console.debug(`[TokenTab][mint] getting UTxOs`)
+      logger.debug(`[TokenTab][mint] getting UTxOs`)
       const hexInputUtxos = await api?.getUtxos()
 
-      console.debug(`[TokenTab][mint] preparing wasmUTxOs`)
+      logger.debug(`[TokenTab][mint] preparing wasmUTxOs`)
       const wasmUtxos = getCslUtxos(hexInputUtxos)
 
-      console.debug(`[TokenTab][mint] adding inputs`)
+      logger.debug(`[TokenTab][mint] adding inputs`)
       txBuilder.add_inputs_from(wasmUtxos, getLargestFirstMultiAsset())
       txBuilder.add_required_signer(pubkeyHash)
       txBuilder.add_change_if_needed(wasmChangeAddress)
       
       const wasmUnsignedTransaction = txBuilder.build_tx()
       const fixedTx = getFixedTxFromBytes(wasmUnsignedTransaction.to_bytes())
-      console.log('[TokenTab] Unsigned Tx:', fixedTx.to_hex())
-      console.debug(`[TokenTab][mint] signing the tx`)
+      logger.log('[TokenTab] Unsigned Tx:', fixedTx.to_hex())
+      logger.debug(`[TokenTab][mint] signing the tx`)
       const witnessHex = await api?.signTx(fixedTx.to_hex())
       const wasmWitnessSet = getTransactionWitnessSetFromBytes(witnessHex)
       const vkeys = wasmWitnessSet.vkeys()
@@ -144,12 +145,12 @@ const TokenTab = () => {
         fixedTx.add_vkey_witness(vkeys.get(i))
       }
       const signedTxHex = fixedTx.to_hex()
-      console.log('[TokenTab][mint] Signed Tx:', signedTxHex)
+      logger.log('[TokenTab][mint] Signed Tx:', signedTxHex)
       const txId = await api?.submitTx(signedTxHex)
-      console.log(`[TokenTab][mint] Transaction successfully submitted: ${txId}`)
+      logger.log(`[TokenTab][mint] Transaction successfully submitted: ${txId}`)
     } catch (error) {
       handleError(error)
-      console.error(error)
+      logger.error(error)
     }
   }
 

--- a/src/components/tabs/subtabs/utilsTab.js
+++ b/src/components/tabs/subtabs/utilsTab.js
@@ -1,15 +1,10 @@
-import React, {useState} from 'react'
+import React from 'react'
+import useResponseState from '../../../hooks/useResponseState'
 import ResponsesPart from './responsesPart'
 import CreateRandomKeyCard from '../../cards/createRandomKeyCard';
 
 const UtilsTab = () => {
-  const [currentText, setCurrentText] = useState('')
-  const [rawCurrentText, setRawCurrentText] = useState('')
-  const [waiterState, setWaiterState] = useState(false)
-
-  const setResponse = (response, stringifyIt = true) => {
-    setCurrentText(stringifyIt ? JSON.stringify(response, undefined, 2) : response);
-  }
+  const {currentText, rawCurrentText, waiterState, setRawCurrentText, setWaiterState, setResponse} = useResponseState()
 
   return (
     <div className="py-5 px-5 text-gray-300">

--- a/src/components/tabs/subtabs/utilsTab.js
+++ b/src/components/tabs/subtabs/utilsTab.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import useResponseState from '../../../hooks/useResponseState'
 import ResponsesPart from './responsesPart'
-import CreateRandomKeyCard from '../../cards/createRandomKeyCard';
+import CreateRandomKeyCard from '../../cards/createRandomKeyCard'
 
 const UtilsTab = () => {
   const {currentText, rawCurrentText, waiterState, setRawCurrentText, setWaiterState, setResponse} = useResponseState()
@@ -14,7 +14,8 @@ const UtilsTab = () => {
             <CreateRandomKeyCard
               onRawResponse={setRawCurrentText}
               onResponse={setResponse}
-              onWaiting={setWaiterState} />
+              onWaiting={setWaiterState}
+            />
           </div>
         </div>
         <ResponsesPart rawCurrentText={rawCurrentText} currentText={currentText} currentWaiterState={waiterState} />

--- a/src/components/tabs/tabsComponent.js
+++ b/src/components/tabs/tabsComponent.js
@@ -12,7 +12,9 @@ const TabsComponent = ({tabsData}) => {
             key={value}
             value={value}
             className={
-              activeTab === value ? 'bg-orange-700 text-white rounded-t-lg whitespace-nowrap' : 'text-gray-300 border-x border-gray-700 whitespace-nowrap'
+              activeTab === value
+                ? 'bg-orange-700 text-white rounded-t-lg whitespace-nowrap'
+                : 'text-gray-300 border-x border-gray-700 whitespace-nowrap'
             }
             onClick={() => setActiveTab(value)}
           >

--- a/src/components/tabs/tabsComponent.js
+++ b/src/components/tabs/tabsComponent.js
@@ -1,8 +1,9 @@
 import React, {useState} from 'react'
-import {Tabs, TabsHeader, TabsBody, Tab, TabPanel} from '@material-tailwind/react'
+import {Tabs, TabsHeader, Tab} from '@material-tailwind/react'
 
 const TabsComponent = ({tabsData}) => {
   const [activeTab, setActiveTab] = useState(tabsData[0].value)
+  const activeTabData = tabsData.find((tab) => tab.value === activeTab)
 
   return (
     <Tabs value={activeTab}>
@@ -22,13 +23,11 @@ const TabsComponent = ({tabsData}) => {
           </Tab>
         ))}
       </TabsHeader>
-      <TabsBody>
-        {tabsData.map(({value, children}) => (
-          <TabPanel key={value} value={value}>
-            {activeTab === value ? children : <div></div>}
-          </TabPanel>
-        ))}
-      </TabsBody>
+      {/* Render only the active tab's content. Material Tailwind's <TabsBody>/
+          <TabPanel> keep inactive panels mounted and absolutely positioned; with
+          no positioned ancestor they collapse to the top-left of the viewport and
+          overlay the page (e.g. the network toggle), swallowing its clicks. */}
+      <div className="text-gray-300">{activeTabData?.children}</div>
     </Tabs>
   )
 }

--- a/src/components/toastContainer.js
+++ b/src/components/toastContainer.js
@@ -1,0 +1,37 @@
+import React from 'react'
+
+const typeStyles = {
+  error: 'bg-red-800 border-red-600',
+  info: 'bg-blue-800 border-blue-600',
+  success: 'bg-green-800 border-green-600',
+}
+
+// Renders the stack of active toasts in the top-right corner.
+const ToastContainer = ({toasts, onDismiss}) => {
+  if (toasts.length === 0) return null
+
+  return (
+    <div className="fixed top-4 right-4 z-50 flex flex-col gap-2 max-w-sm">
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          className={`flex items-start gap-3 rounded-lg border px-4 py-3 text-white shadow-lg ${
+            typeStyles[toast.type] ?? typeStyles.error
+          }`}
+          role="alert"
+        >
+          <span className="flex-1 text-sm break-words">{toast.message}</span>
+          <button
+            className="text-white/70 hover:text-white font-bold leading-none"
+            onClick={() => onDismiss(toast.id)}
+            aria-label="Dismiss"
+          >
+            &times;
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default ToastContainer

--- a/src/components/walletsModal.js
+++ b/src/components/walletsModal.js
@@ -1,10 +1,10 @@
 import React, {useState} from 'react'
 import Popup from 'reactjs-popup'
-import useYoroi from '../hooks/yoroiProvider'
+import useCardano from '../hooks/cardanoProvider'
 import {NO_PROVIDER} from '../utils/connectionStates'
 
 const WalletsModal = () => {
-  const {connect, availableWallets, setSelectedWallet, connectionState} = useYoroi()
+  const {connect, availableWallets, setSelectedWallet, connectionState} = useCardano()
   const [selectedUserWallet, setSelectedUserWallet] = useState('')
   console.log(`[dApp][WalletsModal] is called`)
 

--- a/src/components/walletsModal.js
+++ b/src/components/walletsModal.js
@@ -1,3 +1,4 @@
+import logger from '../utils/logger'
 import React, {useState} from 'react'
 import Popup from 'reactjs-popup'
 import useCardano from '../hooks/cardanoProvider'
@@ -6,13 +7,13 @@ import {NO_PROVIDER} from '../utils/connectionStates'
 const WalletsModal = () => {
   const {connect, availableWallets, setSelectedWallet, connectionState} = useCardano()
   const [selectedUserWallet, setSelectedUserWallet] = useState('')
-  console.log(`[dApp][WalletsModal] is called`)
+  logger.log(`[dApp][WalletsModal] is called`)
 
   const handleSelectionAndClose = (closeFunc) => {
-    console.log(`[dApp][WalletsModal] selected wallet is ${selectedUserWallet}`)
+    logger.log(`[dApp][WalletsModal] selected wallet is ${selectedUserWallet}`)
     setSelectedWallet(selectedUserWallet)
     closeFunc()
-    console.log(`[dApp][WalletsModal] is closed`)
+    logger.log(`[dApp][WalletsModal] is closed`)
     connect(selectedUserWallet, false, false)
   }
 

--- a/src/hooks/bitcoinProvider.js
+++ b/src/hooks/bitcoinProvider.js
@@ -50,7 +50,7 @@ export const BitcoinProvider = ({children}) => {
 
 const useBitcoin = () => {
   const context = React.useContext(BitcoinContext)
-  if (context === undefined) throw new Error('useBitcoin must be used within BitcoinProvider')
+  if (!context) throw new Error('useBitcoin must be used within BitcoinProvider')
   return context
 }
 

--- a/src/hooks/bitcoinProvider.js
+++ b/src/hooks/bitcoinProvider.js
@@ -1,12 +1,13 @@
 import logger from '../utils/logger'
-import React, {useState} from 'react'
-import {NO_PROVIDER} from '../utils/connectionStates'
+import React from 'react'
+import useConnectionState from './useConnectionState'
 
 const BitcoinContext = React.createContext(null)
 
 export const BitcoinProvider = ({children}) => {
   logger.debug('[dApp][BitcoinProvider] is called')
-  const [connectionState] = useState(NO_PROVIDER)
+  // Stub provider — stays NO_PROVIDER until Bitcoin support is implemented.
+  const {connectionState} = useConnectionState()
 
   const connect = async () => {
     logger.warn('[dApp][BitcoinProvider] connect: not implemented')

--- a/src/hooks/bitcoinProvider.js
+++ b/src/hooks/bitcoinProvider.js
@@ -1,37 +1,38 @@
+import logger from '../utils/logger'
 import React, {useState} from 'react'
 import {NO_PROVIDER} from '../utils/connectionStates'
 
 const BitcoinContext = React.createContext(null)
 
 export const BitcoinProvider = ({children}) => {
-  console.debug('[dApp][BitcoinProvider] is called')
+  logger.debug('[dApp][BitcoinProvider] is called')
   const [connectionState] = useState(NO_PROVIDER)
 
   const connect = async () => {
-    console.warn('[dApp][BitcoinProvider] connect: not implemented')
+    logger.warn('[dApp][BitcoinProvider] connect: not implemented')
   }
 
   const disconnect = () => {
-    console.warn('[dApp][BitcoinProvider] disconnect: not implemented')
+    logger.warn('[dApp][BitcoinProvider] disconnect: not implemented')
   }
 
   const getAccounts = async () => {
-    console.warn('[dApp][BitcoinProvider] getAccounts: not implemented')
+    logger.warn('[dApp][BitcoinProvider] getAccounts: not implemented')
     return []
   }
 
   const getBalance = async (_address) => {
-    console.warn('[dApp][BitcoinProvider] getBalance: not implemented')
+    logger.warn('[dApp][BitcoinProvider] getBalance: not implemented')
     return '0'
   }
 
   const sendTransaction = async (_tx) => {
-    console.warn('[dApp][BitcoinProvider] sendTransaction: not implemented')
+    logger.warn('[dApp][BitcoinProvider] sendTransaction: not implemented')
     throw new Error('Bitcoin sendTransaction not implemented')
   }
 
   const signMessage = async (_message) => {
-    console.warn('[dApp][BitcoinProvider] signMessage: not implemented')
+    logger.warn('[dApp][BitcoinProvider] signMessage: not implemented')
     throw new Error('Bitcoin signMessage not implemented')
   }
 

--- a/src/hooks/cardanoProvider.js
+++ b/src/hooks/cardanoProvider.js
@@ -1,7 +1,7 @@
 import logger from '../utils/logger'
 import React, {useState, useEffect, useCallback, useMemo} from 'react'
-import {NOT_CONNECTED, IN_PROGRESS, CONNECTED, NO_PROVIDER} from '../utils/connectionStates'
 import useToast from './toastProvider'
+import useConnectionState from './useConnectionState'
 
 const CardanoContext = React.createContext(null)
 const reservedKeys = [
@@ -27,15 +27,16 @@ const reservedKeys = [
 export const CardanoProvider = ({children}) => {
   logger.debug('[dApp][CardanoProvider] is called')
   const {showToast} = useToast()
+  const {connectionState, setConnectionState, setConnected, setNotConnected, setInProgress, setNoProvider} =
+    useConnectionState()
   const [api, setApi] = useState(null)
-  const [connectionState, setConnectionState] = useState(NO_PROVIDER)
   const [availableWallets, setAvailableWallets] = useState([])
   const [selectedWallet, setSelectedWallet] = useState('')
 
   const setConnectionStateFalse = useCallback(() => {
-    setConnectionState(NOT_CONNECTED)
+    setNotConnected()
     setApi(null)
-  }, [])
+  }, [setNotConnected])
 
   const getAvailableWallets = () => {
     // We need to filter like this because of the Nami wallet.
@@ -58,13 +59,13 @@ export const CardanoProvider = ({children}) => {
    */
   const connect = useCallback(
     async (walletName, requestIdentification, silent, throwError = false) => {
-      setConnectionState(IN_PROGRESS)
+      setInProgress()
       setApi(null)
       logger.debug(`[dApp][connect] is called`)
 
       if (!window.cardano) {
         logger.error('There are no cardano wallets are installed')
-        setConnectionState(NOT_CONNECTED)
+        setNotConnected()
         return
       }
 
@@ -79,12 +80,12 @@ export const CardanoProvider = ({children}) => {
         logger.debug(`[dApp][connect] wallet API object is received`)
         setApi(connectedApi)
         setSelectedWallet(walletName)
-        setConnectionState(CONNECTED)
+        setConnected()
         return connectedApi
       } catch (error) {
         logger.error(`[dApp][connect] The error received while connecting the wallet`)
         setSelectedWallet('')
-        setConnectionState(NOT_CONNECTED)
+        setNotConnected()
         // Surface user-initiated connection failures; stay quiet on the silent
         // background reconnect so page load doesn't pop a toast.
         if (!silent) {
@@ -99,13 +100,13 @@ export const CardanoProvider = ({children}) => {
         }
       }
     },
-    [showToast],
+    [showToast, setInProgress, setNotConnected, setConnected],
   )
 
   useEffect(() => {
     if (!window.cardano) {
       logger.warn('[dApp] There are no cardano wallets are installed')
-      setConnectionState(NO_PROVIDER)
+      setNoProvider()
       return
     }
 
@@ -118,17 +119,17 @@ export const CardanoProvider = ({children}) => {
       logger.debug(`[dApp][tryConnectSilent] is called`)
       try {
         logger.debug(`[dApp][tryConnectSilent] trying {false, true}`)
-        setConnectionState(IN_PROGRESS)
+        setInProgress()
         connectResult = await connect(walletName, false, true, false)
         if (connectResult != null) {
           logger.log('[dApp][tryConnectSilent] RE-CONNECTED!')
           setSelectedWallet(walletName)
-          setConnectionState(CONNECTED)
+          setConnected()
           return
         }
       } catch (error) {
         setSelectedWallet('')
-        setConnectionState(NOT_CONNECTED)
+        setNotConnected()
         logger.error(error)
       }
     }
@@ -147,23 +148,23 @@ export const CardanoProvider = ({children}) => {
           if (response) {
             tryConnectSilent(existingWallet).then()
           } else {
-            setConnectionState(NOT_CONNECTED)
+            setNotConnected()
           }
         })
         .catch((err) => {
-          setConnectionState(NOT_CONNECTED)
+          setNotConnected()
           logger.error(err)
         })
     } else {
-      setConnectionState(NOT_CONNECTED)
+      setNotConnected()
     }
-  }, [connect])
+  }, [connect, setInProgress, setConnected, setNotConnected, setNoProvider])
 
   const disconnect = useCallback(() => {
     setApi(null)
     setSelectedWallet('')
-    setConnectionState(NOT_CONNECTED)
-  }, [])
+    setNotConnected()
+  }, [setNotConnected])
 
   const getAccounts = useCallback(async () => {
     if (!api) return []
@@ -220,6 +221,7 @@ export const CardanoProvider = ({children}) => {
       connectionState,
       availableWallets,
       selectedWallet,
+      setConnectionState,
       setConnectionStateFalse,
     ],
   )

--- a/src/hooks/cardanoProvider.js
+++ b/src/hooks/cardanoProvider.js
@@ -1,6 +1,7 @@
 import logger from '../utils/logger'
 import React, {useState, useEffect, useCallback, useMemo} from 'react'
 import {NOT_CONNECTED, IN_PROGRESS, CONNECTED, NO_PROVIDER} from '../utils/connectionStates'
+import useToast from './toastProvider'
 
 const CardanoContext = React.createContext(null)
 const reservedKeys = [
@@ -25,6 +26,7 @@ const reservedKeys = [
 
 export const CardanoProvider = ({children}) => {
   logger.debug('[dApp][CardanoProvider] is called')
+  const {showToast} = useToast()
   const [api, setApi] = useState(null)
   const [connectionState, setConnectionState] = useState(NO_PROVIDER)
   const [availableWallets, setAvailableWallets] = useState([])
@@ -82,13 +84,18 @@ export const CardanoProvider = ({children}) => {
       logger.error(`[dApp][connect] The error received while connecting the wallet`)
       setSelectedWallet('')
       setConnectionState(NOT_CONNECTED)
+      // Surface user-initiated connection failures; stay quiet on the silent
+      // background reconnect so page load doesn't pop a toast.
+      if (!silent) {
+        showToast(`Failed to connect wallet "${walletName}": ${error?.info ?? error?.message ?? JSON.stringify(error)}`)
+      }
       if (throwError) {
         throw new Error(JSON.stringify(error))
       } else {
         logger.error(`[dApp][connect] ${JSON.stringify(error)}`)
       }
     }
-  }, [])
+  }, [showToast])
 
   useEffect(() => {
     if (!window.cardano) {

--- a/src/hooks/cardanoProvider.js
+++ b/src/hooks/cardanoProvider.js
@@ -56,46 +56,51 @@ export const CardanoProvider = ({children}) => {
    * @param {boolean} throwError - Throw an error which possibly can be while connecting to the wallet
    * @returns {Promise<any>}
    */
-  const connect = useCallback(async (walletName, requestIdentification, silent, throwError = false) => {
-    setConnectionState(IN_PROGRESS)
-    setApi(null)
-    logger.debug(`[dApp][connect] is called`)
+  const connect = useCallback(
+    async (walletName, requestIdentification, silent, throwError = false) => {
+      setConnectionState(IN_PROGRESS)
+      setApi(null)
+      logger.debug(`[dApp][connect] is called`)
 
-    if (!window.cardano) {
-      logger.error('There are no cardano wallets are installed')
-      setConnectionState(NOT_CONNECTED)
-      return
-    }
-
-    logger.log(`[dApp][connect] connecting the wallet "${walletName}"`)
-    logger.debug(`[dApp][connect] {requestIdentification: ${requestIdentification}, onlySilent: ${silent}}`)
-
-    try {
-      const connectedApi = await window.cardano[walletName].enable({
-        requestIdentification,
-        onlySilent: silent,
-      })
-      logger.debug(`[dApp][connect] wallet API object is received`)
-      setApi(connectedApi)
-      setSelectedWallet(walletName)
-      setConnectionState(CONNECTED)
-      return connectedApi
-    } catch (error) {
-      logger.error(`[dApp][connect] The error received while connecting the wallet`)
-      setSelectedWallet('')
-      setConnectionState(NOT_CONNECTED)
-      // Surface user-initiated connection failures; stay quiet on the silent
-      // background reconnect so page load doesn't pop a toast.
-      if (!silent) {
-        showToast(`Failed to connect wallet "${walletName}": ${error?.info ?? error?.message ?? JSON.stringify(error)}`)
+      if (!window.cardano) {
+        logger.error('There are no cardano wallets are installed')
+        setConnectionState(NOT_CONNECTED)
+        return
       }
-      if (throwError) {
-        throw new Error(JSON.stringify(error))
-      } else {
-        logger.error(`[dApp][connect] ${JSON.stringify(error)}`)
+
+      logger.log(`[dApp][connect] connecting the wallet "${walletName}"`)
+      logger.debug(`[dApp][connect] {requestIdentification: ${requestIdentification}, onlySilent: ${silent}}`)
+
+      try {
+        const connectedApi = await window.cardano[walletName].enable({
+          requestIdentification,
+          onlySilent: silent,
+        })
+        logger.debug(`[dApp][connect] wallet API object is received`)
+        setApi(connectedApi)
+        setSelectedWallet(walletName)
+        setConnectionState(CONNECTED)
+        return connectedApi
+      } catch (error) {
+        logger.error(`[dApp][connect] The error received while connecting the wallet`)
+        setSelectedWallet('')
+        setConnectionState(NOT_CONNECTED)
+        // Surface user-initiated connection failures; stay quiet on the silent
+        // background reconnect so page load doesn't pop a toast.
+        if (!silent) {
+          showToast(
+            `Failed to connect wallet "${walletName}": ${error?.info ?? error?.message ?? JSON.stringify(error)}`,
+          )
+        }
+        if (throwError) {
+          throw new Error(JSON.stringify(error))
+        } else {
+          logger.error(`[dApp][connect] ${JSON.stringify(error)}`)
+        }
       }
-    }
-  }, [showToast])
+    },
+    [showToast],
+  )
 
   useEffect(() => {
     if (!window.cardano) {
@@ -105,9 +110,9 @@ export const CardanoProvider = ({children}) => {
     }
 
     /**
-   * @param {string} walletName - A wallet name as it is presented in the Cardano object
-   * @returns {Promise<void>}
-   */
+     * @param {string} walletName - A wallet name as it is presented in the Cardano object
+     * @returns {Promise<void>}
+     */
     const tryConnectSilent = async (walletName) => {
       let connectResult = null
       logger.debug(`[dApp][tryConnectSilent] is called`)
@@ -150,7 +155,7 @@ export const CardanoProvider = ({children}) => {
           logger.error(err)
         })
     } else {
-      setConnectionState(NOT_CONNECTED);
+      setConnectionState(NOT_CONNECTED)
     }
   }, [connect])
 
@@ -170,33 +175,54 @@ export const CardanoProvider = ({children}) => {
     return await api.getBalance()
   }, [api])
 
-  const sendTransaction = useCallback(async (tx) => {
-    if (!api) throw new Error('Not connected')
-    const signedTx = await api.signTx(tx)
-    return await api.submitTx(signedTx)
-  }, [api])
+  const sendTransaction = useCallback(
+    async (tx) => {
+      if (!api) throw new Error('Not connected')
+      const signedTx = await api.signTx(tx)
+      return await api.submitTx(signedTx)
+    },
+    [api],
+  )
 
-  const signMessage = useCallback(async (address, payload) => {
-    if (!api) throw new Error('Not connected')
-    return await api.signData(address, payload)
-  }, [api])
+  const signMessage = useCallback(
+    async (address, payload) => {
+      if (!api) throw new Error('Not connected')
+      return await api.signData(address, payload)
+    },
+    [api],
+  )
 
-  const values = useMemo(() => ({
-    api,
-    connect,
-    disconnect,
-    getAccounts,
-    getBalance,
-    sendTransaction,
-    signMessage,
-    connectionState,
-    availableWallets,
-    setAvailableWallets,
-    selectedWallet,
-    setConnectionState,
-    setConnectionStateFalse,
-    setSelectedWallet,
-  }), [api, connect, disconnect, getAccounts, getBalance, sendTransaction, signMessage, connectionState, availableWallets, selectedWallet, setConnectionStateFalse])
+  const values = useMemo(
+    () => ({
+      api,
+      connect,
+      disconnect,
+      getAccounts,
+      getBalance,
+      sendTransaction,
+      signMessage,
+      connectionState,
+      availableWallets,
+      setAvailableWallets,
+      selectedWallet,
+      setConnectionState,
+      setConnectionStateFalse,
+      setSelectedWallet,
+    }),
+    [
+      api,
+      connect,
+      disconnect,
+      getAccounts,
+      getBalance,
+      sendTransaction,
+      signMessage,
+      connectionState,
+      availableWallets,
+      selectedWallet,
+      setConnectionStateFalse,
+    ],
+  )
 
   return <CardanoContext.Provider value={values}>{children}</CardanoContext.Provider>
 }

--- a/src/hooks/cardanoProvider.js
+++ b/src/hooks/cardanoProvider.js
@@ -1,7 +1,7 @@
 import React, {useState, useEffect} from 'react'
 import {NOT_CONNECTED, IN_PROGRESS, CONNECTED, NO_PROVIDER} from '../utils/connectionStates'
 
-const YoroiContext = React.createContext(null)
+const CardanoContext = React.createContext(null)
 const reservedKeys = [
   'enable',
   'isEnabled',
@@ -22,8 +22,8 @@ const reservedKeys = [
   '_events',
 ]
 
-export const YoroiProvider = ({children}) => {
-  console.debug('[dApp][YoroiProvider] is called')
+export const CardanoProvider = ({children}) => {
+  console.debug('[dApp][CardanoProvider] is called')
   const [api, setApi] = useState(null)
   const [connectionState, setConnectionState] = useState(NO_PROVIDER)
   const [availableWallets, setAvailableWallets] = useState([])
@@ -105,12 +105,12 @@ export const YoroiProvider = ({children}) => {
 
   /**
    * @param {string} walletName - A wallet name as it is presented in the Cardano object
-   * @param {bool} requestId - Request connection with or without required authentication
-   * @param {bool} silent - Request connection with or without showing the connection pop-up
-   * @param {bool} throwError - Throw an error which possibly can be while connecting to the wallet
+   * @param {boolean} requestIdentification - Request connection with or without required authentication
+   * @param {boolean} silent - Request connection with or without showing the connection pop-up
+   * @param {boolean} throwError - Throw an error which possibly can be while connecting to the wallet
    * @returns {Promise<any>}
    */
-  const connect = async (walletName, requestId, silent, throwError = false) => {
+  const connect = async (walletName, requestIdentification, silent, throwError = false) => {
     setConnectionState(IN_PROGRESS)
     setApi(null)
     console.debug(`[dApp][connect] is called`)
@@ -122,11 +122,11 @@ export const YoroiProvider = ({children}) => {
     }
 
     console.log(`[dApp][connect] connecting the wallet "${walletName}"`)
-    console.debug(`[dApp][connect] {requestIdentification: ${requestId}, onlySilent: ${silent}}`)
+    console.debug(`[dApp][connect] {requestIdentification: ${requestIdentification}, onlySilent: ${silent}}`)
 
     try {
       const connectedApi = await window.cardano[walletName].enable({
-        requestIdentification: requestId,
+        requestIdentification,
         onlySilent: silent,
       })
       console.debug(`[dApp][connect] wallet API object is received`)
@@ -190,17 +190,17 @@ export const YoroiProvider = ({children}) => {
     setSelectedWallet,
   }
 
-  return <YoroiContext.Provider value={values}>{children}</YoroiContext.Provider>
+  return <CardanoContext.Provider value={values}>{children}</CardanoContext.Provider>
 }
 
-const useYoroi = () => {
-  const context = React.useContext(YoroiContext)
+const useCardano = () => {
+  const context = React.useContext(CardanoContext)
 
-  if (context === undefined) {
-    throw new Error('Install Yoroi')
+  if (!context) {
+    throw new Error('useCardano must be used within CardanoProvider')
   }
 
   return context
 }
 
-export default useYoroi
+export default useCardano

--- a/src/hooks/cardanoProvider.js
+++ b/src/hooks/cardanoProvider.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react'
+import React, {useState, useEffect, useCallback, useMemo} from 'react'
 import {NOT_CONNECTED, IN_PROGRESS, CONNECTED, NO_PROVIDER} from '../utils/connectionStates'
 
 const CardanoContext = React.createContext(null)
@@ -29,10 +29,10 @@ export const CardanoProvider = ({children}) => {
   const [availableWallets, setAvailableWallets] = useState([])
   const [selectedWallet, setSelectedWallet] = useState('')
 
-  const setConnectionStateFalse = () => {
+  const setConnectionStateFalse = useCallback(() => {
     setConnectionState(NOT_CONNECTED)
     setApi(null)
-  }
+  }, [])
 
   const getAvailableWallets = () => {
     // We need to filter like this because of the Nami wallet.
@@ -45,6 +45,49 @@ export const CardanoProvider = ({children}) => {
       }
     })
   }
+
+  /**
+   * @param {string} walletName - A wallet name as it is presented in the Cardano object
+   * @param {boolean} requestIdentification - Request connection with or without required authentication
+   * @param {boolean} silent - Request connection with or without showing the connection pop-up
+   * @param {boolean} throwError - Throw an error which possibly can be while connecting to the wallet
+   * @returns {Promise<any>}
+   */
+  const connect = useCallback(async (walletName, requestIdentification, silent, throwError = false) => {
+    setConnectionState(IN_PROGRESS)
+    setApi(null)
+    console.debug(`[dApp][connect] is called`)
+
+    if (!window.cardano) {
+      console.error('There are no cardano wallets are installed')
+      setConnectionState(NOT_CONNECTED)
+      return
+    }
+
+    console.log(`[dApp][connect] connecting the wallet "${walletName}"`)
+    console.debug(`[dApp][connect] {requestIdentification: ${requestIdentification}, onlySilent: ${silent}}`)
+
+    try {
+      const connectedApi = await window.cardano[walletName].enable({
+        requestIdentification,
+        onlySilent: silent,
+      })
+      console.debug(`[dApp][connect] wallet API object is received`)
+      setApi(connectedApi)
+      setSelectedWallet(walletName)
+      setConnectionState(CONNECTED)
+      return connectedApi
+    } catch (error) {
+      console.error(`[dApp][connect] The error received while connecting the wallet`)
+      setSelectedWallet('')
+      setConnectionState(NOT_CONNECTED)
+      if (throwError) {
+        throw new Error(JSON.stringify(error))
+      } else {
+        console.error(`[dApp][connect] ${JSON.stringify(error)}`)
+      }
+    }
+  }, [])
 
   useEffect(() => {
     if (!window.cardano) {
@@ -101,79 +144,36 @@ export const CardanoProvider = ({children}) => {
     } else {
       setConnectionState(NOT_CONNECTED);
     }
-  }, [])
+  }, [connect])
 
-  /**
-   * @param {string} walletName - A wallet name as it is presented in the Cardano object
-   * @param {boolean} requestIdentification - Request connection with or without required authentication
-   * @param {boolean} silent - Request connection with or without showing the connection pop-up
-   * @param {boolean} throwError - Throw an error which possibly can be while connecting to the wallet
-   * @returns {Promise<any>}
-   */
-  const connect = async (walletName, requestIdentification, silent, throwError = false) => {
-    setConnectionState(IN_PROGRESS)
-    setApi(null)
-    console.debug(`[dApp][connect] is called`)
-
-    if (!window.cardano) {
-      console.error('There are no cardano wallets are installed')
-      setConnectionState(NOT_CONNECTED)
-      return
-    }
-
-    console.log(`[dApp][connect] connecting the wallet "${walletName}"`)
-    console.debug(`[dApp][connect] {requestIdentification: ${requestIdentification}, onlySilent: ${silent}}`)
-
-    try {
-      const connectedApi = await window.cardano[walletName].enable({
-        requestIdentification,
-        onlySilent: silent,
-      })
-      console.debug(`[dApp][connect] wallet API object is received`)
-      setApi(connectedApi)
-      setSelectedWallet(walletName)
-      setConnectionState(CONNECTED)
-      return connectedApi
-    } catch (error) {
-      console.error(`[dApp][connect] The error received while connecting the wallet`)
-      setSelectedWallet('')
-      setConnectionState(NOT_CONNECTED)
-      if (throwError) {
-        throw new Error(JSON.stringify(error))
-      } else {
-        console.error(`[dApp][connect] ${JSON.stringify(error)}`)
-      }
-    }
-  }
-
-  const disconnect = () => {
+  const disconnect = useCallback(() => {
     setApi(null)
     setSelectedWallet('')
     setConnectionState(NOT_CONNECTED)
-  }
+  }, [])
 
-  const getAccounts = async () => {
+  const getAccounts = useCallback(async () => {
     if (!api) return []
     return await api.getUsedAddresses()
-  }
+  }, [api])
 
-  const getBalance = async () => {
+  const getBalance = useCallback(async () => {
     if (!api) return '0'
     return await api.getBalance()
-  }
+  }, [api])
 
-  const sendTransaction = async (tx) => {
+  const sendTransaction = useCallback(async (tx) => {
     if (!api) throw new Error('Not connected')
     const signedTx = await api.signTx(tx)
     return await api.submitTx(signedTx)
-  }
+  }, [api])
 
-  const signMessage = async (address, payload) => {
+  const signMessage = useCallback(async (address, payload) => {
     if (!api) throw new Error('Not connected')
     return await api.signData(address, payload)
-  }
+  }, [api])
 
-  const values = {
+  const values = useMemo(() => ({
     api,
     connect,
     disconnect,
@@ -188,7 +188,7 @@ export const CardanoProvider = ({children}) => {
     setConnectionState,
     setConnectionStateFalse,
     setSelectedWallet,
-  }
+  }), [api, connect, disconnect, getAccounts, getBalance, sendTransaction, signMessage, connectionState, availableWallets, selectedWallet, setConnectionStateFalse])
 
   return <CardanoContext.Provider value={values}>{children}</CardanoContext.Provider>
 }

--- a/src/hooks/cardanoProvider.js
+++ b/src/hooks/cardanoProvider.js
@@ -1,3 +1,4 @@
+import logger from '../utils/logger'
 import React, {useState, useEffect, useCallback, useMemo} from 'react'
 import {NOT_CONNECTED, IN_PROGRESS, CONNECTED, NO_PROVIDER} from '../utils/connectionStates'
 
@@ -23,7 +24,7 @@ const reservedKeys = [
 ]
 
 export const CardanoProvider = ({children}) => {
-  console.debug('[dApp][CardanoProvider] is called')
+  logger.debug('[dApp][CardanoProvider] is called')
   const [api, setApi] = useState(null)
   const [connectionState, setConnectionState] = useState(NO_PROVIDER)
   const [availableWallets, setAvailableWallets] = useState([])
@@ -56,42 +57,42 @@ export const CardanoProvider = ({children}) => {
   const connect = useCallback(async (walletName, requestIdentification, silent, throwError = false) => {
     setConnectionState(IN_PROGRESS)
     setApi(null)
-    console.debug(`[dApp][connect] is called`)
+    logger.debug(`[dApp][connect] is called`)
 
     if (!window.cardano) {
-      console.error('There are no cardano wallets are installed')
+      logger.error('There are no cardano wallets are installed')
       setConnectionState(NOT_CONNECTED)
       return
     }
 
-    console.log(`[dApp][connect] connecting the wallet "${walletName}"`)
-    console.debug(`[dApp][connect] {requestIdentification: ${requestIdentification}, onlySilent: ${silent}}`)
+    logger.log(`[dApp][connect] connecting the wallet "${walletName}"`)
+    logger.debug(`[dApp][connect] {requestIdentification: ${requestIdentification}, onlySilent: ${silent}}`)
 
     try {
       const connectedApi = await window.cardano[walletName].enable({
         requestIdentification,
         onlySilent: silent,
       })
-      console.debug(`[dApp][connect] wallet API object is received`)
+      logger.debug(`[dApp][connect] wallet API object is received`)
       setApi(connectedApi)
       setSelectedWallet(walletName)
       setConnectionState(CONNECTED)
       return connectedApi
     } catch (error) {
-      console.error(`[dApp][connect] The error received while connecting the wallet`)
+      logger.error(`[dApp][connect] The error received while connecting the wallet`)
       setSelectedWallet('')
       setConnectionState(NOT_CONNECTED)
       if (throwError) {
         throw new Error(JSON.stringify(error))
       } else {
-        console.error(`[dApp][connect] ${JSON.stringify(error)}`)
+        logger.error(`[dApp][connect] ${JSON.stringify(error)}`)
       }
     }
   }, [])
 
   useEffect(() => {
     if (!window.cardano) {
-      console.warn('[dApp] There are no cardano wallets are installed')
+      logger.warn('[dApp] There are no cardano wallets are installed')
       setConnectionState(NO_PROVIDER)
       return
     }
@@ -102,13 +103,13 @@ export const CardanoProvider = ({children}) => {
    */
     const tryConnectSilent = async (walletName) => {
       let connectResult = null
-      console.debug(`[dApp][tryConnectSilent] is called`)
+      logger.debug(`[dApp][tryConnectSilent] is called`)
       try {
-        console.debug(`[dApp][tryConnectSilent] trying {false, true}`)
+        logger.debug(`[dApp][tryConnectSilent] trying {false, true}`)
         setConnectionState(IN_PROGRESS)
         connectResult = await connect(walletName, false, true, false)
         if (connectResult != null) {
-          console.log('[dApp][tryConnectSilent] RE-CONNECTED!')
+          logger.log('[dApp][tryConnectSilent] RE-CONNECTED!')
           setSelectedWallet(walletName)
           setConnectionState(CONNECTED)
           return
@@ -116,12 +117,12 @@ export const CardanoProvider = ({children}) => {
       } catch (error) {
         setSelectedWallet('')
         setConnectionState(NOT_CONNECTED)
-        console.error(error)
+        logger.error(error)
       }
     }
 
     const availableWallets = getAvailableWallets()
-    console.log('[dApp] allInfoWallets: ', availableWallets)
+    logger.log('[dApp] allInfoWallets: ', availableWallets)
     setAvailableWallets(availableWallets)
 
     if (availableWallets.length === 1) {
@@ -130,7 +131,7 @@ export const CardanoProvider = ({children}) => {
       walletObject
         .isEnabled()
         .then((response) => {
-          console.debug(`[dApp] Connection is enabled: ${response}`)
+          logger.debug(`[dApp] Connection is enabled: ${response}`)
           if (response) {
             tryConnectSilent(existingWallet).then()
           } else {
@@ -139,7 +140,7 @@ export const CardanoProvider = ({children}) => {
         })
         .catch((err) => {
           setConnectionState(NOT_CONNECTED)
-          console.error(err)
+          logger.error(err)
         })
     } else {
       setConnectionState(NOT_CONNECTED);

--- a/src/hooks/chainProvider.js
+++ b/src/hooks/chainProvider.js
@@ -1,0 +1,18 @@
+// The shared contract every chain provider implements. Each provider (Cardano,
+// Ethereum, Bitcoin) exposes at least this shape through its React context;
+// chain-specific extras (Cardano's selectedWallet/availableWallets, Ethereum's
+// chainId, ...) are layered on top. See CLAUDE.md "Multi-Chain Abstraction".
+//
+// Connection state is driven by the shared useConnectionState() machine and
+// uses the values from utils/connectionStates.js.
+//
+// @typedef {Object} ChainProvider
+// @property {string} connectionState                    NOT_CONNECTED | IN_PROGRESS | CONNECTED | NO_PROVIDER
+// @property {(...args: any[]) => Promise<any>} connect
+// @property {() => void} disconnect
+// @property {() => (string[] | Promise<string[]>)} getAccounts
+// @property {(address?: string) => Promise<string>} getBalance
+// @property {(tx: any) => Promise<string>} sendTransaction
+// @property {(...args: any[]) => Promise<any>} signMessage
+
+export {}

--- a/src/hooks/ethereumProvider.js
+++ b/src/hooks/ethereumProvider.js
@@ -1,24 +1,25 @@
+import logger from '../utils/logger'
 import React, {useState, useEffect, useCallback, useMemo} from 'react'
 import {NOT_CONNECTED, IN_PROGRESS, CONNECTED, NO_PROVIDER} from '../utils/connectionStates'
 
 const EthereumContext = React.createContext(null)
 
 export const EthereumProvider = ({children}) => {
-  console.debug('[dApp][EthereumProvider] is called')
+  logger.debug('[dApp][EthereumProvider] is called')
   const [accounts, setAccounts] = useState([])
   const [connectionState, setConnectionState] = useState(NO_PROVIDER)
   const [chainId, setChainId] = useState(null)
 
   useEffect(() => {
     if (!window.ethereum) {
-      console.warn('[dApp] No Ethereum wallet found')
+      logger.warn('[dApp] No Ethereum wallet found')
       setConnectionState(NO_PROVIDER)
       return
     }
     setConnectionState(NOT_CONNECTED)
 
     const handleAccountsChanged = (newAccounts) => {
-      console.debug('[dApp][EthereumProvider] accountsChanged', newAccounts)
+      logger.debug('[dApp][EthereumProvider] accountsChanged', newAccounts)
       if (newAccounts.length === 0) {
         setConnectionState(NOT_CONNECTED)
         setAccounts([])
@@ -29,7 +30,7 @@ export const EthereumProvider = ({children}) => {
     }
 
     const handleChainChanged = (newChainId) => {
-      console.debug('[dApp][EthereumProvider] chainChanged', newChainId)
+      logger.debug('[dApp][EthereumProvider] chainChanged', newChainId)
       setChainId(newChainId)
     }
 
@@ -45,16 +46,16 @@ export const EthereumProvider = ({children}) => {
   const connect = useCallback(async () => {
     if (!window.ethereum) return
     setConnectionState(IN_PROGRESS)
-    console.debug('[dApp][EthereumProvider] connect is called')
+    logger.debug('[dApp][EthereumProvider] connect is called')
     try {
       const accs = await window.ethereum.request({method: 'eth_requestAccounts'})
       const chain = await window.ethereum.request({method: 'eth_chainId'})
       setAccounts(accs)
       setChainId(chain)
       setConnectionState(CONNECTED)
-      console.log('[dApp][EthereumProvider] CONNECTED, accounts:', accs)
+      logger.log('[dApp][EthereumProvider] CONNECTED, accounts:', accs)
     } catch (err) {
-      console.error('[dApp][EthereumProvider] connect error', err)
+      logger.error('[dApp][EthereumProvider] connect error', err)
       setConnectionState(NOT_CONNECTED)
     }
   }, [])

--- a/src/hooks/ethereumProvider.js
+++ b/src/hooks/ethereumProvider.js
@@ -80,22 +80,28 @@ export const EthereumProvider = ({children}) => {
     return await window.ethereum.request({method: 'eth_sendTransaction', params: [tx]})
   }, [])
 
-  const signMessage = useCallback(async (message) => {
-    if (!window.ethereum || accounts.length === 0) throw new Error('Not connected')
-    return await window.ethereum.request({method: 'personal_sign', params: [message, accounts[0]]})
-  }, [accounts])
+  const signMessage = useCallback(
+    async (message) => {
+      if (!window.ethereum || accounts.length === 0) throw new Error('Not connected')
+      return await window.ethereum.request({method: 'personal_sign', params: [message, accounts[0]]})
+    },
+    [accounts],
+  )
 
-  const values = useMemo(() => ({
-    accounts,
-    connectionState,
-    chainId,
-    connect,
-    disconnect,
-    getAccounts,
-    getBalance,
-    sendTransaction,
-    signMessage,
-  }), [accounts, connectionState, chainId, connect, disconnect, getAccounts, getBalance, sendTransaction, signMessage])
+  const values = useMemo(
+    () => ({
+      accounts,
+      connectionState,
+      chainId,
+      connect,
+      disconnect,
+      getAccounts,
+      getBalance,
+      sendTransaction,
+      signMessage,
+    }),
+    [accounts, connectionState, chainId, connect, disconnect, getAccounts, getBalance, sendTransaction, signMessage],
+  )
 
   return <EthereumContext.Provider value={values}>{children}</EthereumContext.Provider>
 }

--- a/src/hooks/ethereumProvider.js
+++ b/src/hooks/ethereumProvider.js
@@ -1,11 +1,13 @@
 import logger from '../utils/logger'
 import React, {useState, useEffect, useCallback, useMemo} from 'react'
 import {NOT_CONNECTED, IN_PROGRESS, CONNECTED, NO_PROVIDER} from '../utils/connectionStates'
+import useToast from './toastProvider'
 
 const EthereumContext = React.createContext(null)
 
 export const EthereumProvider = ({children}) => {
   logger.debug('[dApp][EthereumProvider] is called')
+  const {showToast} = useToast()
   const [accounts, setAccounts] = useState([])
   const [connectionState, setConnectionState] = useState(NO_PROVIDER)
   const [chainId, setChainId] = useState(null)
@@ -57,8 +59,9 @@ export const EthereumProvider = ({children}) => {
     } catch (err) {
       logger.error('[dApp][EthereumProvider] connect error', err)
       setConnectionState(NOT_CONNECTED)
+      showToast(`Failed to connect Ethereum wallet: ${err?.message ?? JSON.stringify(err)}`)
     }
-  }, [])
+  }, [showToast])
 
   const disconnect = useCallback(() => {
     setAccounts([])

--- a/src/hooks/ethereumProvider.js
+++ b/src/hooks/ethereumProvider.js
@@ -98,7 +98,7 @@ export const EthereumProvider = ({children}) => {
 
 const useEthereum = () => {
   const context = React.useContext(EthereumContext)
-  if (context === undefined) throw new Error('useEthereum must be used within EthereumProvider')
+  if (!context) throw new Error('useEthereum must be used within EthereumProvider')
   return context
 }
 

--- a/src/hooks/ethereumProvider.js
+++ b/src/hooks/ethereumProvider.js
@@ -1,33 +1,33 @@
 import logger from '../utils/logger'
 import React, {useState, useEffect, useCallback, useMemo} from 'react'
-import {NOT_CONNECTED, IN_PROGRESS, CONNECTED, NO_PROVIDER} from '../utils/connectionStates'
 import useToast from './toastProvider'
+import useConnectionState from './useConnectionState'
 
 const EthereumContext = React.createContext(null)
 
 export const EthereumProvider = ({children}) => {
   logger.debug('[dApp][EthereumProvider] is called')
   const {showToast} = useToast()
+  const {connectionState, setConnected, setNotConnected, setInProgress, setNoProvider} = useConnectionState()
   const [accounts, setAccounts] = useState([])
-  const [connectionState, setConnectionState] = useState(NO_PROVIDER)
   const [chainId, setChainId] = useState(null)
 
   useEffect(() => {
     if (!window.ethereum) {
       logger.warn('[dApp] No Ethereum wallet found')
-      setConnectionState(NO_PROVIDER)
+      setNoProvider()
       return
     }
-    setConnectionState(NOT_CONNECTED)
+    setNotConnected()
 
     const handleAccountsChanged = (newAccounts) => {
       logger.debug('[dApp][EthereumProvider] accountsChanged', newAccounts)
       if (newAccounts.length === 0) {
-        setConnectionState(NOT_CONNECTED)
+        setNotConnected()
         setAccounts([])
       } else {
         setAccounts(newAccounts)
-        setConnectionState(CONNECTED)
+        setConnected()
       }
     }
 
@@ -43,30 +43,30 @@ export const EthereumProvider = ({children}) => {
       window.ethereum.removeListener('accountsChanged', handleAccountsChanged)
       window.ethereum.removeListener('chainChanged', handleChainChanged)
     }
-  }, [])
+  }, [setNoProvider, setNotConnected, setConnected])
 
   const connect = useCallback(async () => {
     if (!window.ethereum) return
-    setConnectionState(IN_PROGRESS)
+    setInProgress()
     logger.debug('[dApp][EthereumProvider] connect is called')
     try {
       const accs = await window.ethereum.request({method: 'eth_requestAccounts'})
       const chain = await window.ethereum.request({method: 'eth_chainId'})
       setAccounts(accs)
       setChainId(chain)
-      setConnectionState(CONNECTED)
+      setConnected()
       logger.log('[dApp][EthereumProvider] CONNECTED, accounts:', accs)
     } catch (err) {
       logger.error('[dApp][EthereumProvider] connect error', err)
-      setConnectionState(NOT_CONNECTED)
+      setNotConnected()
       showToast(`Failed to connect Ethereum wallet: ${err?.message ?? JSON.stringify(err)}`)
     }
-  }, [showToast])
+  }, [showToast, setInProgress, setConnected, setNotConnected])
 
   const disconnect = useCallback(() => {
     setAccounts([])
-    setConnectionState(NOT_CONNECTED)
-  }, [])
+    setNotConnected()
+  }, [setNotConnected])
 
   const getAccounts = useCallback(() => accounts, [accounts])
 

--- a/src/hooks/toastProvider.js
+++ b/src/hooks/toastProvider.js
@@ -1,0 +1,47 @@
+import React, {useState, useRef, useCallback, useMemo} from 'react'
+import ToastContainer from '../components/toastContainer'
+
+const ToastContext = React.createContext(null)
+
+const AUTO_DISMISS_MS = 6000
+
+// App-wide toast notifications. Any component can call `useToast().showToast(...)`
+// to surface a message (errors, info) as a visible banner instead of a
+// console-only log.
+export const ToastProvider = ({children}) => {
+  const [toasts, setToasts] = useState([])
+  const nextId = useRef(0)
+
+  const dismissToast = useCallback((id) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id))
+  }, [])
+
+  const showToast = useCallback(
+    (message, type = 'error') => {
+      const id = ++nextId.current
+      setToasts((current) => [...current, {id, message, type}])
+      setTimeout(() => dismissToast(id), AUTO_DISMISS_MS)
+      return id
+    },
+    [dismissToast],
+  )
+
+  const value = useMemo(() => ({showToast, dismissToast}), [showToast, dismissToast])
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+    </ToastContext.Provider>
+  )
+}
+
+const useToast = () => {
+  const context = React.useContext(ToastContext)
+  if (!context) {
+    throw new Error('useToast must be used within ToastProvider')
+  }
+  return context
+}
+
+export default useToast

--- a/src/hooks/toastProvider.test.js
+++ b/src/hooks/toastProvider.test.js
@@ -1,0 +1,54 @@
+import {render, screen, fireEvent, act} from '@testing-library/react'
+import useToast, {ToastProvider} from './toastProvider'
+
+const Trigger = () => {
+  const {showToast} = useToast()
+  return <button onClick={() => showToast('Boom happened')}>go</button>
+}
+
+describe('ToastProvider', () => {
+  it('shows a toast and dismisses it via the close button', () => {
+    render(
+      <ToastProvider>
+        <Trigger />
+      </ToastProvider>,
+    )
+
+    fireEvent.click(screen.getByText('go'))
+    expect(screen.getByRole('alert')).toHaveTextContent('Boom happened')
+
+    fireEvent.click(screen.getByLabelText('Dismiss'))
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('auto-dismisses after the timeout', () => {
+    jest.useFakeTimers()
+    try {
+      render(
+        <ToastProvider>
+          <Trigger />
+        </ToastProvider>,
+      )
+
+      fireEvent.click(screen.getByText('go'))
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+
+      act(() => {
+        jest.advanceTimersByTime(6000)
+      })
+      expect(screen.queryByRole('alert')).toBeNull()
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  it('throws when useToast is used outside the provider', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const Bad = () => {
+      useToast()
+      return null
+    }
+    expect(() => render(<Bad />)).toThrow('useToast must be used within ToastProvider')
+    spy.mockRestore()
+  })
+})

--- a/src/hooks/useConnectionState.js
+++ b/src/hooks/useConnectionState.js
@@ -1,0 +1,19 @@
+import {useState, useCallback} from 'react'
+import {NOT_CONNECTED, IN_PROGRESS, CONNECTED, NO_PROVIDER} from '../utils/connectionStates'
+
+// Shared connection-state machine used by every chain provider so the
+// NOT_CONNECTED / IN_PROGRESS / CONNECTED / NO_PROVIDER transitions stay
+// consistent across chains. Returns the raw setter too, for the rare caller
+// that needs it (e.g. App's reconnect polling via the Cardano context).
+const useConnectionState = (initial = NO_PROVIDER) => {
+  const [connectionState, setConnectionState] = useState(initial)
+
+  const setConnected = useCallback(() => setConnectionState(CONNECTED), [])
+  const setNotConnected = useCallback(() => setConnectionState(NOT_CONNECTED), [])
+  const setInProgress = useCallback(() => setConnectionState(IN_PROGRESS), [])
+  const setNoProvider = useCallback(() => setConnectionState(NO_PROVIDER), [])
+
+  return {connectionState, setConnectionState, setConnected, setNotConnected, setInProgress, setNoProvider}
+}
+
+export default useConnectionState

--- a/src/hooks/useConnectionState.test.js
+++ b/src/hooks/useConnectionState.test.js
@@ -1,0 +1,38 @@
+import {renderHook, act} from '@testing-library/react'
+import useConnectionState from './useConnectionState'
+import {CONNECTED, IN_PROGRESS, NOT_CONNECTED, NO_PROVIDER} from '../utils/connectionStates'
+
+describe('useConnectionState', () => {
+  it('defaults to NO_PROVIDER', () => {
+    const {result} = renderHook(() => useConnectionState())
+    expect(result.current.connectionState).toBe(NO_PROVIDER)
+  })
+
+  it('honors a custom initial state', () => {
+    const {result} = renderHook(() => useConnectionState(NOT_CONNECTED))
+    expect(result.current.connectionState).toBe(NOT_CONNECTED)
+  })
+
+  it('transitions through the named setters', () => {
+    const {result} = renderHook(() => useConnectionState())
+
+    act(() => result.current.setInProgress())
+    expect(result.current.connectionState).toBe(IN_PROGRESS)
+
+    act(() => result.current.setConnected())
+    expect(result.current.connectionState).toBe(CONNECTED)
+
+    act(() => result.current.setNotConnected())
+    expect(result.current.connectionState).toBe(NOT_CONNECTED)
+
+    act(() => result.current.setNoProvider())
+    expect(result.current.connectionState).toBe(NO_PROVIDER)
+  })
+
+  it('keeps setter identities stable across renders', () => {
+    const {result, rerender} = renderHook(() => useConnectionState())
+    const firstSetConnected = result.current.setConnected
+    rerender()
+    expect(result.current.setConnected).toBe(firstSetConnected)
+  })
+})

--- a/src/hooks/useResponseState.js
+++ b/src/hooks/useResponseState.js
@@ -1,0 +1,18 @@
+import {useState, useCallback} from 'react'
+
+// Shared response state used by every subtab: the "Part" components write results
+// through setResponse / setRawCurrentText / setWaiterState, and ResponsesPart
+// renders currentText / rawCurrentText / waiterState.
+const useResponseState = () => {
+  const [currentText, setCurrentText] = useState('')
+  const [rawCurrentText, setRawCurrentText] = useState('')
+  const [waiterState, setWaiterState] = useState(false)
+
+  const setResponse = useCallback((response, stringifyIt = true) => {
+    setCurrentText(stringifyIt ? JSON.stringify(response, undefined, 2) : response)
+  }, [])
+
+  return {currentText, rawCurrentText, waiterState, setRawCurrentText, setWaiterState, setResponse}
+}
+
+export default useResponseState

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import './index.css'
 import App from './App'
-import {YoroiProvider} from './hooks/yoroiProvider'
+import {CardanoProvider} from './hooks/cardanoProvider'
 import {NetworkProvider} from './hooks/networkProvider'
 import {EthereumProvider} from './hooks/ethereumProvider'
 import {BitcoinProvider} from './hooks/bitcoinProvider'
@@ -12,7 +12,7 @@ const root = ReactDOM.createRoot(document.getElementById('root'))
 root.render(
   <React.StrictMode>
     <NetworkProvider>
-      <YoroiProvider>
+      <CardanoProvider>
         <EthereumProvider>
           <BitcoinProvider>
           <BrowserRouter>
@@ -22,7 +22,7 @@ root.render(
           </BrowserRouter>
           </BitcoinProvider>
         </EthereumProvider>
-      </YoroiProvider>
+      </CardanoProvider>
     </NetworkProvider>
   </React.StrictMode>,
 )

--- a/src/index.js
+++ b/src/index.js
@@ -6,23 +6,26 @@ import {CardanoProvider} from './hooks/cardanoProvider'
 import {NetworkProvider} from './hooks/networkProvider'
 import {EthereumProvider} from './hooks/ethereumProvider'
 import {BitcoinProvider} from './hooks/bitcoinProvider'
+import {ToastProvider} from './hooks/toastProvider'
 import {BrowserRouter, Route, Routes} from 'react-router-dom'
 
 const root = ReactDOM.createRoot(document.getElementById('root'))
 root.render(
   <React.StrictMode>
-    <NetworkProvider>
-      <CardanoProvider>
-        <EthereumProvider>
-          <BitcoinProvider>
-            <BrowserRouter>
-              <Routes>
-                <Route path="/*" element={<App />} />
-              </Routes>
-            </BrowserRouter>
-          </BitcoinProvider>
-        </EthereumProvider>
-      </CardanoProvider>
-    </NetworkProvider>
+    <ToastProvider>
+      <NetworkProvider>
+        <CardanoProvider>
+          <EthereumProvider>
+            <BitcoinProvider>
+              <BrowserRouter>
+                <Routes>
+                  <Route path="/*" element={<App />} />
+                </Routes>
+              </BrowserRouter>
+            </BitcoinProvider>
+          </EthereumProvider>
+        </CardanoProvider>
+      </NetworkProvider>
+    </ToastProvider>
   </React.StrictMode>,
 )

--- a/src/index.js
+++ b/src/index.js
@@ -15,11 +15,11 @@ root.render(
       <CardanoProvider>
         <EthereumProvider>
           <BitcoinProvider>
-          <BrowserRouter>
-            <Routes>
-              <Route path="/*" element={<App />} />
-            </Routes>
-          </BrowserRouter>
+            <BrowserRouter>
+              <Routes>
+                <Route path="/*" element={<App />} />
+              </Routes>
+            </BrowserRouter>
           </BitcoinProvider>
         </EthereumProvider>
       </CardanoProvider>

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,3 @@
+// Adds custom jest matchers such as toBeInTheDocument().
+// Automatically loaded by Create React App / craco before each test file.
+import '@testing-library/jest-dom'

--- a/src/utils/buildCert.js
+++ b/src/utils/buildCert.js
@@ -1,0 +1,18 @@
+import logger from './logger'
+
+// Shared envelope for the governance cert panels: flip the waiting flag, hand a
+// fresh cert builder to the panel's buildFn (which adds its certificate(s) and
+// attaches them to the tx), and route any failure to onError.
+export const buildCert = (getCertBuilder, {onWaiting, onError}, buildFn) => {
+  onWaiting(true)
+  try {
+    buildFn(getCertBuilder())
+    onWaiting(false)
+  } catch (error) {
+    logger.error(error)
+    onWaiting(false)
+    onError()
+  }
+}
+
+export default buildCert

--- a/src/utils/cslTools.js
+++ b/src/utils/cslTools.js
@@ -300,6 +300,24 @@ export const getCslCredentialFromBech32 = (bech32Value) => {
   return cred
 }
 
+// Parse a credential input as Hex, falling back to Bech32. Throws (rather than
+// returning null) on invalid input so the caller's try/catch handles cleanup
+// instead of feeding null into CSL and crashing with the opaque
+// "expected instance of Fe".
+export const parseCredential = (input) => {
+  try {
+    return getCslCredentialFromHex(input)
+  } catch (err1) {
+    try {
+      return getCslCredentialFromBech32(input)
+    } catch (err2) {
+      throw new Error(
+        `Invalid credential — not valid Hex or Bech32: ${JSON.stringify(err1)}, ${JSON.stringify(err2)}`,
+      )
+    }
+  }
+}
+
 export const getCslCredentialFromScriptFromBech32 = (bech32Value) => {
   logger.debug('[cslTools][getCslCredentialFromScriptFromBech32]::bech32Value', bech32Value)
   const scriptHash = wasm.ScriptHash.from_bech32(bech32Value)

--- a/src/utils/cslTools.js
+++ b/src/utils/cslTools.js
@@ -240,6 +240,9 @@ export const getAssetName = (assetNameString) => wasm.AssetName.new(Buffer.from(
 
 export const getBech32AddressFromHex = (addressHex) => wasm.Address.from_bytes(hexToBytes(addressHex)).to_bech32()
 
+// Decode an array of hex addresses (as returned by the wallet) to bech32.
+export const hexArrayToBech32Addresses = (hexAddresses) => hexAddresses.map(getBech32AddressFromHex)
+
 export const getAddressFromBech32 = (bech32Value) => wasm.Address.from_bech32(bech32Value)
 
 export const getCslValue = (hexValue) => wasm.Value.from_hex(hexValue)
@@ -259,6 +262,9 @@ export const getUtxoFromHex = (hexUtxo) => {
   utxo.hex = hexUtxo
   return utxo
 }
+
+// Decode an array of hex UTxOs (as returned by the wallet) to UTxO objects.
+export const hexArrayToUtxos = (hexUtxos) => hexUtxos.map(getUtxoFromHex)
 
 export const getTransactionHashFromHex = (txHex) => wasm.TransactionHash.from_hex(txHex)
 

--- a/src/utils/cslTools.js
+++ b/src/utils/cslTools.js
@@ -216,8 +216,7 @@ export const buildCip20Tx = ({hexUtxos, receiverBech32, messageLines, pickedHexU
 
 // Descending comparator for lovelace amount strings (UI sort of decoded UTxOs).
 // Uses wasm.BigNum (not native BigInt, which trips the react-app ESLint no-undef).
-export const compareLovelaceDesc = (aStr, bStr) =>
-  wasm.BigNum.from_str(bStr).compare(wasm.BigNum.from_str(aStr))
+export const compareLovelaceDesc = (aStr, bStr) => wasm.BigNum.from_str(bStr).compare(wasm.BigNum.from_str(aStr))
 
 export const getAddressFromBytes = (changeAddress) => wasm.Address.from_bytes(hexToBytes(changeAddress))
 
@@ -227,7 +226,6 @@ export const getTransactionWitnessSetNew = () => wasm.TransactionWitnessSet.new(
 
 export const getTransactionWitnessSetFromBytes = (witnessHex) =>
   wasm.TransactionWitnessSet.from_bytes(hexToBytes(witnessHex))
-
 
 export const getPubKeyHash = (usedAddress) => wasm.BaseAddress.from_address(usedAddress).payment_cred().to_keyhash()
 
@@ -311,9 +309,7 @@ export const parseCredential = (input) => {
     try {
       return getCslCredentialFromBech32(input)
     } catch (err2) {
-      throw new Error(
-        `Invalid credential — not valid Hex or Bech32: ${JSON.stringify(err1)}, ${JSON.stringify(err2)}`,
-      )
+      throw new Error(`Invalid credential — not valid Hex or Bech32: ${JSON.stringify(err1)}, ${JSON.stringify(err2)}`)
     }
   }
 }
@@ -337,8 +333,8 @@ export const getCslCredentialFromScriptFromHex = (hexValue) => {
 }
 
 /**
- * 
- * @param {wasm.Credential} dRepCred 
+ *
+ * @param {wasm.Credential} dRepCred
  * @returns {boolean}
  */
 export const dRepIsScript = (dRepCred) => dRepCred.kind() === wasm.CredKind.Script

--- a/src/utils/cslTools.js
+++ b/src/utils/cslTools.js
@@ -56,31 +56,6 @@ export const getTransactionOutput = (wasmOutputAddress, buildTransactionInput) =
 
 // ---- CIP-20 (transaction message metadata, label 674) ----
 
-// Splits a string into an array of chunks each <= 64 bytes when UTF-8 encoded.
-// CSL's metadatum text strings are capped at 64 BYTES (not chars); anything
-// larger makes encode_json_str_to_metadatum throw. We accumulate whole code
-// points (iterating the string yields code points, not UTF-16 units) so we
-// never split a multibyte character mid-sequence.
-export const chunkMessageTo64Bytes = (message) => {
-  const encoder = new TextEncoder()
-  const chunks = []
-  let current = ''
-  let currentBytes = 0
-  for (const ch of message) {
-    const chBytes = encoder.encode(ch).length
-    if (currentBytes + chBytes > 64) {
-      if (current) chunks.push(current)
-      current = ch
-      currentBytes = chBytes
-    } else {
-      current += ch
-      currentBytes += chBytes
-    }
-  }
-  if (current) chunks.push(current)
-  return chunks
-}
-
 // Builds an unsigned CIP-20 transaction:
 //  - one explicit 1 ADA output to `receiverBech32`
 //  - a label-674 { "msg": [...] } metadata entry from `messageLines`

--- a/src/utils/cslTools.js
+++ b/src/utils/cslTools.js
@@ -1,3 +1,4 @@
+import logger from './logger'
 import {protocolParams} from './networkConfig'
 import {hexToBytes, bytesToHex, wasmMultiassetToJSONs} from './utils'
 import {Buffer} from 'buffer'
@@ -276,38 +277,38 @@ export const keyHashFromHex = (hexValue) => wasm.Ed25519KeyHash.from_hex(hexValu
 export const keyHashFromBech32 = (bech32Value) => wasm.Ed25519KeyHash.from_bech32(bech32Value)
 
 export const getCslCredentialFromHex = (hexValue) => {
-  console.debug('[cslTools][getCslCredentialFromHex]::hexValue', hexValue)
+  logger.debug('[cslTools][getCslCredentialFromHex]::hexValue', hexValue)
   const keyHash = keyHashFromHex(hexValue)
-  console.debug('[cslTools][getCslCredentialFromHex]::keyHash', keyHash)
+  logger.debug('[cslTools][getCslCredentialFromHex]::keyHash', keyHash)
   const cred = getCredential(keyHash)
-  console.debug('[cslTools][getCslCredentialFromHex]::cred', cred)
+  logger.debug('[cslTools][getCslCredentialFromHex]::cred', cred)
   return cred
 }
 
 export const getCslCredentialFromBech32 = (bech32Value) => {
-  console.debug('[cslTools][getCslCredentialFromBech32]::bech32Value', bech32Value)
+  logger.debug('[cslTools][getCslCredentialFromBech32]::bech32Value', bech32Value)
   const keyHash = keyHashFromBech32(bech32Value)
-  console.debug('[cslTools][getCslCredentialFromBech32]::keyHash', keyHash)
+  logger.debug('[cslTools][getCslCredentialFromBech32]::keyHash', keyHash)
   const cred = getCredential(keyHash)
-  console.debug('[cslTools][getCslCredentialFromBech32]::cred', cred)
+  logger.debug('[cslTools][getCslCredentialFromBech32]::cred', cred)
   return cred
 }
 
 export const getCslCredentialFromScriptFromBech32 = (bech32Value) => {
-  console.debug('[cslTools][getCslCredentialFromScriptFromBech32]::bech32Value', bech32Value)
+  logger.debug('[cslTools][getCslCredentialFromScriptFromBech32]::bech32Value', bech32Value)
   const scriptHash = wasm.ScriptHash.from_bech32(bech32Value)
-  console.debug('[cslTools][getCslCredentialFromScriptFromBech32]::scriptHash', scriptHash)
+  logger.debug('[cslTools][getCslCredentialFromScriptFromBech32]::scriptHash', scriptHash)
   const cred = getCredentialFromScriptHash(scriptHash)
-  console.debug('[cslTools][getCslCredentialFromScriptFromBech32]::cred', cred)
+  logger.debug('[cslTools][getCslCredentialFromScriptFromBech32]::cred', cred)
   return cred
 }
 
 export const getCslCredentialFromScriptFromHex = (hexValue) => {
-  console.debug('[cslTools][getCslCredentialFromScriptFromHex]::hexValue', hexValue)
+  logger.debug('[cslTools][getCslCredentialFromScriptFromHex]::hexValue', hexValue)
   const scriptHash = wasm.ScriptHash.from_hex(hexValue)
-  console.debug('[cslTools][getCslCredentialFromScriptFromHex]::scriptHash', scriptHash)
+  logger.debug('[cslTools][getCslCredentialFromScriptFromHex]::scriptHash', scriptHash)
   const cred = getCredentialFromScriptHash(scriptHash)
-  console.debug('[cslTools][getCslCredentialFromScriptFromHex]::cred', cred)
+  logger.debug('[cslTools][getCslCredentialFromScriptFromHex]::cred', cred)
   return cred
 }
 

--- a/src/utils/ethereumUtils.js
+++ b/src/utils/ethereumUtils.js
@@ -8,10 +8,14 @@ export const CHAIN_IDS = Object.freeze({
 
 export const chainName = (chainId) => {
   switch (chainId) {
-    case CHAIN_IDS.MAINNET: return 'Mainnet'
-    case CHAIN_IDS.SEPOLIA: return 'Sepolia'
-    case CHAIN_IDS.HOLESKY: return 'Holesky'
-    default: return chainId ?? 'Unknown'
+    case CHAIN_IDS.MAINNET:
+      return 'Mainnet'
+    case CHAIN_IDS.SEPOLIA:
+      return 'Sepolia'
+    case CHAIN_IDS.HOLESKY:
+      return 'Holesky'
+    default:
+      return chainId ?? 'Unknown'
   }
 }
 
@@ -38,21 +42,17 @@ export const ethToHexWei = (ethStr) => {
 /**
  * Format an address for display (0x1234...abcd)
  */
-export const shortAddress = (addr) =>
-  addr ? `${addr.slice(0, 6)}...${addr.slice(-4)}` : ''
+export const shortAddress = (addr) => (addr ? `${addr.slice(0, 6)}...${addr.slice(-4)}` : '')
 
 /**
  * ERC-20 balanceOf(address) ABI encoding
  * selector: keccak256('balanceOf(address)')[0..3] = 0x70a08231
  */
-export const balanceOfData = (addr) =>
-  '0x70a08231' + addr.slice(2).toLowerCase().padStart(64, '0')
+export const balanceOfData = (addr) => '0x70a08231' + addr.slice(2).toLowerCase().padStart(64, '0')
 
 /**
  * ERC-20 transfer(address,uint256) ABI encoding
  * selector: keccak256('transfer(address,uint256)')[0..3] = 0xa9059cbb
  */
 export const transferData = (to, amountWei) =>
-  '0xa9059cbb' +
-  to.slice(2).toLowerCase().padStart(64, '0') +
-  BigInt(amountWei).toString(16).padStart(64, '0')
+  '0xa9059cbb' + to.slice(2).toLowerCase().padStart(64, '0') + BigInt(amountWei).toString(16).padStart(64, '0')

--- a/src/utils/ethereumUtils.test.js
+++ b/src/utils/ethereumUtils.test.js
@@ -1,0 +1,80 @@
+import {
+  CHAIN_IDS,
+  chainName,
+  weiHexToEth,
+  ethToHexWei,
+  shortAddress,
+  balanceOfData,
+  transferData,
+} from './ethereumUtils'
+
+describe('chainName', () => {
+  it('maps known chain ids to readable names', () => {
+    expect(chainName(CHAIN_IDS.MAINNET)).toBe('Mainnet')
+    expect(chainName(CHAIN_IDS.SEPOLIA)).toBe('Sepolia')
+    expect(chainName(CHAIN_IDS.HOLESKY)).toBe('Holesky')
+  })
+
+  it('returns the raw id for unknown chains', () => {
+    expect(chainName('0x99')).toBe('0x99')
+  })
+
+  it('returns "Unknown" when no chain id is given', () => {
+    expect(chainName(undefined)).toBe('Unknown')
+  })
+})
+
+describe('weiHexToEth', () => {
+  it('converts whole ether', () => {
+    expect(weiHexToEth('0xde0b6b3a7640000')).toBe('1.0') // 1e18 wei
+  })
+
+  it('converts fractional ether and trims trailing zeros', () => {
+    expect(weiHexToEth('0x6f05b59d3b20000')).toBe('0.5') // 5e17 wei
+  })
+
+  it('handles zero', () => {
+    expect(weiHexToEth('0x0')).toBe('0.0')
+  })
+})
+
+describe('ethToHexWei', () => {
+  it('converts an ether string to hex wei', () => {
+    expect(ethToHexWei('1')).toBe('0xde0b6b3a7640000')
+  })
+
+  it('round-trips with weiHexToEth', () => {
+    expect(weiHexToEth(ethToHexWei('2.5'))).toBe('2.5')
+  })
+})
+
+describe('shortAddress', () => {
+  it('shortens a full address', () => {
+    expect(shortAddress('0x1234567890abcdef1234567890abcdef12345678')).toBe('0x1234...5678')
+  })
+
+  it('returns empty string for falsy input', () => {
+    expect(shortAddress('')).toBe('')
+    expect(shortAddress(undefined)).toBe('')
+  })
+})
+
+describe('ERC-20 ABI encoders', () => {
+  const addr = '0x1234567890abcdef1234567890abcdef12345678'
+
+  it('encodes balanceOf(address)', () => {
+    const data = balanceOfData(addr)
+    expect(data.startsWith('0x70a08231')).toBe(true)
+    // selector (8) + 0x (2) + 64 hex chars of padded address
+    expect(data.length).toBe(2 + 8 + 64)
+    expect(data.endsWith(addr.slice(2))).toBe(true)
+  })
+
+  it('encodes transfer(address,uint256)', () => {
+    const data = transferData(addr, '1')
+    expect(data.startsWith('0xa9059cbb')).toBe(true)
+    // selector (8) + 0x (2) + 64 (address) + 64 (amount)
+    expect(data.length).toBe(2 + 8 + 64 + 64)
+    expect(data.endsWith('1'.padStart(64, '0'))).toBe(true)
+  })
+})

--- a/src/utils/helpFunctions.js
+++ b/src/utils/helpFunctions.js
@@ -1,4 +1,10 @@
-import {getCslValue, getUtxoFromHex, getBech32AddressFromHex, getPublicKeyFromHex} from './cslTools'
+import {
+  getCslValue,
+  getBech32AddressFromHex,
+  getPublicKeyFromHex,
+  hexArrayToBech32Addresses,
+  hexArrayToUtxos,
+} from './cslTools'
 
 // Returns the first element of a wallet-returned array, or throws a clear error
 // if the wallet returned nothing. Prevents `undefined` from flowing into CSL
@@ -19,13 +25,8 @@ export const getBalance = async (api) => {
 }
 
 export const getUTxOs = async (api, amountLovelaces, requestParam = {page: 0, limit: 20}) => {
-  const utxos = []
   const hexUtxos = await api.getUtxos(amountLovelaces, requestParam)
-  for (const hexUtxo of hexUtxos) {
-    const utxo = getUtxoFromHex(hexUtxo)
-    utxos.push(utxo)
-  }
-  return utxos
+  return hexArrayToUtxos(hexUtxos)
 }
 
 export const getChangeAddress = async (api) => {
@@ -35,11 +36,7 @@ export const getChangeAddress = async (api) => {
 
 export const getRewardAddress = async (api) => {
   const hexAddresses = await api.getRewardAddresses()
-  const addresses = []
-  for (const hexAddr of hexAddresses) {
-    addresses.push(getBech32AddressFromHex(hexAddr))
-  }
-  return addresses[0]
+  return hexArrayToBech32Addresses(hexAddresses)[0]
 }
 
 export const getPubDRepKey = async (api) => {
@@ -79,20 +76,12 @@ export const getUnregPubStakeKey = async (api) => {
 export const getUsedAddress = async (api) => {
   const requestParam = {page: 0, limit: 1}
   const hexAddresses = await api.getUsedAddresses(requestParam)
-  const addresses = []
-  for (const hexAddr of hexAddresses) {
-    addresses.push(getBech32AddressFromHex(hexAddr))
-  }
-  return addresses[0]
+  return hexArrayToBech32Addresses(hexAddresses)[0]
 }
 
 export const getUnusedAddress = async (api) => {
   const hexAddresses = await api.getUnusedAddresses()
-  const addresses = []
-  for (const hexAddr of hexAddresses) {
-    addresses.push(getBech32AddressFromHex(hexAddr))
-  }
-  return addresses[0]
+  return hexArrayToBech32Addresses(hexAddresses)[0]
 }
 
 const randomBytes = (count) => {

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,24 +1,86 @@
-// Debug-gated logger.
+// Debug-gated logger with a runtime on/off switch.
 //
-// `debug`, `log` and `info` only print when debug output is enabled — during
-// local development (NODE_ENV === 'development') or when the app is built with
-// REACT_APP_DEBUG=true. `warn` and `error` always print so real problems stay
-// visible in production.
-const isDebugEnabled =
+// `debug`, `log` and `info` only print when debug output is enabled;
+// `warn` and `error` always print so real problems stay visible in production.
+//
+// Enabled state is resolved in this order:
+//   1. A runtime override saved in localStorage (set from the browser console).
+//   2. The build-time default: on during local development, or when the app is
+//      built with REACT_APP_DEBUG=true.
+//
+// Toggle logs live from the browser console without rebuilding:
+//   dappLogs.on()      // enable and remember across reloads
+//   dappLogs.off()     // disable and remember across reloads
+//   dappLogs.toggle()  // flip current state
+//   dappLogs.status()  // -> true | false
+//   dappLogs.reset()   // forget the override, fall back to the build default
+const STORAGE_KEY = 'dapp:debug'
+
+const buildDefault =
   process.env.NODE_ENV === 'development' || process.env.REACT_APP_DEBUG === 'true'
+
+const readOverride = () => {
+  try {
+    const value = window.localStorage.getItem(STORAGE_KEY)
+    if (value === 'true') return true
+    if (value === 'false') return false
+  } catch (e) {
+    // localStorage may be unavailable (SSR, privacy mode) — ignore.
+  }
+  return null
+}
+
+const override = readOverride()
+let enabled = override === null ? buildDefault : override
+
+const persist = (value) => {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(value))
+  } catch (e) {
+    // ignore write failures
+  }
+}
+
+const setEnabled = (value) => {
+  enabled = !!value
+  persist(enabled)
+  // Always report the switch itself so the user sees the effect immediately.
+  console.info(`[dApp][logger] logging ${enabled ? 'ENABLED' : 'DISABLED'}`)
+  return enabled
+}
 
 const logger = {
   debug: (...args) => {
-    if (isDebugEnabled) console.debug(...args)
+    if (enabled) console.debug(...args)
   },
   log: (...args) => {
-    if (isDebugEnabled) console.log(...args)
+    if (enabled) console.log(...args)
   },
   info: (...args) => {
-    if (isDebugEnabled) console.info(...args)
+    if (enabled) console.info(...args)
   },
   warn: (...args) => console.warn(...args),
   error: (...args) => console.error(...args),
+}
+
+// Expose runtime controls on window so logs can be toggled from the console.
+if (typeof window !== 'undefined') {
+  window.dappLogs = {
+    on: () => setEnabled(true),
+    off: () => setEnabled(false),
+    toggle: () => setEnabled(!enabled),
+    status: () => enabled,
+    reset: () => {
+      try {
+        window.localStorage.removeItem(STORAGE_KEY)
+      } catch (e) {
+        // ignore
+      }
+      enabled = buildDefault
+      console.info(`[dApp][logger] override cleared, logging ${enabled ? 'ENABLED' : 'DISABLED'} (build default)`)
+      return enabled
+    },
+  }
 }
 
 export default logger

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -16,8 +16,7 @@
 //   dappLogs.reset()   // forget the override, fall back to the build default
 const STORAGE_KEY = 'dapp:debug'
 
-const buildDefault =
-  process.env.NODE_ENV === 'development' || process.env.REACT_APP_DEBUG === 'true'
+const buildDefault = process.env.NODE_ENV === 'development' || process.env.REACT_APP_DEBUG === 'true'
 
 const readOverride = () => {
   try {

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,24 @@
+// Debug-gated logger.
+//
+// `debug`, `log` and `info` only print when debug output is enabled — during
+// local development (NODE_ENV === 'development') or when the app is built with
+// REACT_APP_DEBUG=true. `warn` and `error` always print so real problems stay
+// visible in production.
+const isDebugEnabled =
+  process.env.NODE_ENV === 'development' || process.env.REACT_APP_DEBUG === 'true'
+
+const logger = {
+  debug: (...args) => {
+    if (isDebugEnabled) console.debug(...args)
+  },
+  log: (...args) => {
+    if (isDebugEnabled) console.log(...args)
+  },
+  info: (...args) => {
+    if (isDebugEnabled) console.info(...args)
+  },
+  warn: (...args) => console.warn(...args),
+  error: (...args) => console.error(...args),
+}
+
+export default logger

--- a/src/utils/logger.test.js
+++ b/src/utils/logger.test.js
@@ -1,0 +1,76 @@
+// NODE_ENV is 'test' here, so the build default is "logging off" — which lets us
+// assert the gating and the runtime toggle cleanly.
+describe('logger', () => {
+  beforeEach(() => {
+    jest.resetModules() // re-evaluate logger.js so it re-reads localStorage
+    window.localStorage.clear()
+    jest.restoreAllMocks()
+  })
+
+  it('does not print debug/log when disabled (build default in test env)', () => {
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const logger = require('./logger').default
+
+    logger.debug('nope')
+    logger.log('nope')
+
+    expect(debugSpy).not.toHaveBeenCalled()
+    expect(logSpy).not.toHaveBeenCalled()
+  })
+
+  it('always prints warn and error regardless of state', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const logger = require('./logger').default
+
+    logger.warn('w')
+    logger.error('e')
+
+    expect(warnSpy).toHaveBeenCalledWith('w')
+    expect(errorSpy).toHaveBeenCalledWith('e')
+  })
+
+  it('reads a persisted override on load', () => {
+    window.localStorage.setItem('dapp:debug', 'true')
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+    const logger = require('./logger').default
+
+    logger.debug('yes')
+
+    expect(debugSpy).toHaveBeenCalledWith('yes')
+  })
+
+  it('exposes window.dappLogs controls that toggle output and persist', () => {
+    jest.spyOn(console, 'info').mockImplementation(() => {})
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+    const logger = require('./logger').default
+
+    expect(window.dappLogs.status()).toBe(false)
+
+    window.dappLogs.on()
+    expect(window.dappLogs.status()).toBe(true)
+    expect(window.localStorage.getItem('dapp:debug')).toBe('true')
+    logger.debug('on')
+    expect(debugSpy).toHaveBeenCalledWith('on')
+
+    debugSpy.mockClear()
+    window.dappLogs.off()
+    expect(window.dappLogs.status()).toBe(false)
+    logger.debug('off')
+    expect(debugSpy).not.toHaveBeenCalled()
+  })
+
+  it('reset() clears the override and falls back to the build default', () => {
+    window.localStorage.setItem('dapp:debug', 'true')
+    jest.spyOn(console, 'info').mockImplementation(() => {})
+    const logger = require('./logger').default
+
+    expect(window.dappLogs.status()).toBe(true)
+    window.dappLogs.reset()
+
+    expect(window.localStorage.getItem('dapp:debug')).toBeNull()
+    expect(window.dappLogs.status()).toBe(false) // build default in test env
+    void logger
+  })
+})

--- a/src/utils/logger.test.js
+++ b/src/utils/logger.test.js
@@ -1,3 +1,7 @@
+// These tests call the app logger's own debug(), not RTL's screen.debug(), so the
+// testing-library debugging-utils rule is a false positive here.
+/* eslint-disable testing-library/no-debugging-utils */
+
 // NODE_ENV is 'test' here, so the build default is "logging off" — which lets us
 // assert the gating and the runtime toggle cleanly.
 describe('logger', () => {

--- a/src/utils/runApiCall.js
+++ b/src/utils/runApiCall.js
@@ -1,0 +1,28 @@
+import logger from './logger'
+
+// Shared lifecycle for the API cards: flip the waiting flag, run the wallet
+// call, then publish the raw response and a parsed result — or publish the error.
+// Collapses the identical then/catch envelope that every card used to repeat.
+//
+//   call            () => Promise<raw>   the wallet/API call to run
+//   handlers        { onRawResponse, onResponse, onWaiting }  (card props)
+//   options.parse   (raw) => result      value passed to onResponse (default: identity)
+//   options.rawText (raw) => shown       value passed to onRawResponse (default: identity)
+//   options.stringify  boolean           2nd arg to onResponse (default: true)
+export const runApiCall = async (call, {onRawResponse, onResponse, onWaiting}, options = {}) => {
+  const {parse = (raw) => raw, rawText = (raw) => raw, stringify = true} = options
+  onWaiting(true)
+  try {
+    const raw = await call()
+    onRawResponse(rawText(raw))
+    onResponse(parse(raw), stringify)
+  } catch (e) {
+    onRawResponse('')
+    onResponse(e)
+    logger.error(e)
+  } finally {
+    onWaiting(false)
+  }
+}
+
+export default runApiCall

--- a/src/utils/runApiCall.test.js
+++ b/src/utils/runApiCall.test.js
@@ -1,0 +1,47 @@
+import {runApiCall} from './runApiCall'
+
+const makeHandlers = () => ({
+  onRawResponse: jest.fn(),
+  onResponse: jest.fn(),
+  onWaiting: jest.fn(),
+})
+
+describe('runApiCall', () => {
+  it('toggles waiting on then off around a successful call', async () => {
+    const handlers = makeHandlers()
+    await runApiCall(() => Promise.resolve('ok'), handlers)
+
+    expect(handlers.onWaiting).toHaveBeenNthCalledWith(1, true)
+    expect(handlers.onWaiting).toHaveBeenLastCalledWith(false)
+  })
+
+  it('publishes the raw and parsed response (stringify default true)', async () => {
+    const handlers = makeHandlers()
+    await runApiCall(() => Promise.resolve('42'), handlers)
+
+    expect(handlers.onRawResponse).toHaveBeenCalledWith('42')
+    expect(handlers.onResponse).toHaveBeenCalledWith('42', true)
+  })
+
+  it('applies parse, rawText and stringify options', async () => {
+    const handlers = makeHandlers()
+    await runApiCall(() => Promise.resolve(2), handlers, {
+      parse: (n) => n * 10,
+      rawText: (n) => `raw:${n}`,
+      stringify: false,
+    })
+
+    expect(handlers.onRawResponse).toHaveBeenCalledWith('raw:2')
+    expect(handlers.onResponse).toHaveBeenCalledWith(20, false)
+  })
+
+  it('publishes the error and clears raw on failure', async () => {
+    const handlers = makeHandlers()
+    const err = new Error('boom')
+    await runApiCall(() => Promise.reject(err), handlers)
+
+    expect(handlers.onRawResponse).toHaveBeenCalledWith('')
+    expect(handlers.onResponse).toHaveBeenCalledWith(err)
+    expect(handlers.onWaiting).toHaveBeenLastCalledWith(false)
+  })
+})

--- a/src/utils/testTxBuilder.js
+++ b/src/utils/testTxBuilder.js
@@ -127,16 +127,12 @@ export const FEATURE_GROUPS = [
 
 /** Canonical test native script for 'script' mode — its hash is the script credential */
 function getTestScriptNativeScript() {
-  return wasm.NativeScript.new_script_pubkey(
-    wasm.ScriptPubkey.new(wasm.Ed25519KeyHash.from_hex(PAYMENT_KEY_HASH)),
-  )
+  return wasm.NativeScript.new_script_pubkey(wasm.ScriptPubkey.new(wasm.Ed25519KeyHash.from_hex(PAYMENT_KEY_HASH)))
 }
 
 function resolveStakeCred(mode, walletRewardAddrHex) {
   if (mode === 'wallet' && walletRewardAddrHex) {
-    const rewardAddr = wasm.RewardAddress.from_address(
-      wasm.Address.from_bytes(hexToBytes(walletRewardAddrHex)),
-    )
+    const rewardAddr = wasm.RewardAddress.from_address(wasm.Address.from_bytes(hexToBytes(walletRewardAddrHex)))
     return rewardAddr.payment_cred()
   }
   if (mode === 'script') {
@@ -148,9 +144,7 @@ function resolveStakeCred(mode, walletRewardAddrHex) {
 
 function resolveRewardAddr(mode, walletRewardAddrHex, networkId) {
   if (mode === 'wallet' && walletRewardAddrHex) {
-    return wasm.RewardAddress.from_address(
-      wasm.Address.from_bytes(hexToBytes(walletRewardAddrHex)),
-    )
+    return wasm.RewardAddress.from_address(wasm.Address.from_bytes(hexToBytes(walletRewardAddrHex)))
   }
   const cred = resolveStakeCred(mode, walletRewardAddrHex)
   return wasm.RewardAddress.new(networkId, cred)
@@ -190,9 +184,7 @@ export function buildTestTx(enabledFeatures, credModes, walletRewardAddrHex, wal
   // Native script used for mint/burn — defined here so the policy ID is available
   // when constructing the fake UTXO (burn requires tokens in inputs)
   const mintPolicyKeyHash = wasm.Ed25519KeyHash.from_hex(PAYMENT_KEY_HASH)
-  const mintNativeScript = wasm.NativeScript.new_script_pubkey(
-    wasm.ScriptPubkey.new(mintPolicyKeyHash),
-  )
+  const mintNativeScript = wasm.NativeScript.new_script_pubkey(wasm.ScriptPubkey.new(mintPolicyKeyHash))
 
   // Fake input UTXO: enterprise address with 10,000 ADA
   // When burn is enabled, also include the tokens to be burned so coin selection can balance
@@ -203,10 +195,7 @@ export function buildTestTx(enabledFeatures, credModes, walletRewardAddrHex, wal
   if (enabledFeatures.has('burn')) {
     const burnMultiAsset = wasm.MultiAsset.new()
     const burnAssets = wasm.Assets.new()
-    burnAssets.insert(
-      wasm.AssetName.new(Buffer.from('4255524e', 'hex')),
-      strToBigNum('500'),
-    )
+    burnAssets.insert(wasm.AssetName.new(Buffer.from('4255524e', 'hex')), strToBigNum('500'))
     burnMultiAsset.insert(mintNativeScript.hash(), burnAssets)
     fakeValue.set_multiasset(burnMultiAsset)
   }
@@ -216,9 +205,7 @@ export function buildTestTx(enabledFeatures, credModes, walletRewardAddrHex, wal
   fakeUtxos.add(fakeUtxo)
 
   // Base output: 2 ADA to change address
-  txBuilder.add_output(
-    wasm.TransactionOutput.new(changeAddr, wasm.Value.new(strToBigNum('2000000'))),
-  )
+  txBuilder.add_output(wasm.TransactionOutput.new(changeAddr, wasm.Value.new(strToBigNum('2000000'))))
 
   // ---- Certificates ----
   const certBuilder = wasm.CertificatesBuilder.new()
@@ -231,7 +218,11 @@ export function buildTestTx(enabledFeatures, credModes, walletRewardAddrHex, wal
   }
   if (enabledFeatures.has('legacyStakeDeReg')) {
     const cred = resolveStakeCred(getMode('legacyStakeDeReg'), walletRewardAddrHex)
-    addCertToBuilder(certBuilder, wasm.Certificate.new_stake_deregistration(wasm.StakeDeregistration.new(cred)), getMode('legacyStakeDeReg'))
+    addCertToBuilder(
+      certBuilder,
+      wasm.Certificate.new_stake_deregistration(wasm.StakeDeregistration.new(cred)),
+      getMode('legacyStakeDeReg'),
+    )
     hasCerts = true
   }
   if (enabledFeatures.has('stakeDelegation')) {
@@ -270,9 +261,7 @@ export function buildTestTx(enabledFeatures, credModes, walletRewardAddrHex, wal
     const cred = resolveStakeCred(getMode('voteDelegation'), walletRewardAddrHex)
     addCertToBuilder(
       certBuilder,
-      wasm.Certificate.new_vote_delegation(
-        wasm.VoteDelegation.new(cred, wasm.DRep.new_always_abstain()),
-      ),
+      wasm.Certificate.new_vote_delegation(wasm.VoteDelegation.new(cred, wasm.DRep.new_always_abstain())),
       getMode('voteDelegation'),
     )
     hasCerts = true
@@ -306,11 +295,7 @@ export function buildTestTx(enabledFeatures, credModes, walletRewardAddrHex, wal
     addCertToBuilder(
       certBuilder,
       wasm.Certificate.new_vote_registration_and_delegation(
-        wasm.VoteRegistrationAndDelegation.new(
-          cred,
-          wasm.DRep.new_always_abstain(),
-          strToBigNum('2000000'),
-        ),
+        wasm.VoteRegistrationAndDelegation.new(cred, wasm.DRep.new_always_abstain(), strToBigNum('2000000')),
       ),
       getMode('voteRegDelegation'),
     )
@@ -336,18 +321,14 @@ export function buildTestTx(enabledFeatures, credModes, walletRewardAddrHex, wal
   if (enabledFeatures.has('drepRegistration')) {
     const drepCred = wasm.Credential.from_keyhash(wasm.Ed25519KeyHash.from_hex(DREP_KEY_HASH))
     certBuilder.add(
-      wasm.Certificate.new_drep_registration(
-        wasm.DRepRegistration.new(drepCred, strToBigNum('500000000')),
-      ),
+      wasm.Certificate.new_drep_registration(wasm.DRepRegistration.new(drepCred, strToBigNum('500000000'))),
     )
     hasCerts = true
   }
   if (enabledFeatures.has('drepRetirement')) {
     const drepCred = wasm.Credential.from_keyhash(wasm.Ed25519KeyHash.from_hex(DREP_KEY_HASH))
     certBuilder.add(
-      wasm.Certificate.new_drep_deregistration(
-        wasm.DRepDeregistration.new(drepCred, strToBigNum('500000000')),
-      ),
+      wasm.Certificate.new_drep_deregistration(wasm.DRepDeregistration.new(drepCred, strToBigNum('500000000'))),
     )
     hasCerts = true
   }
@@ -359,16 +340,12 @@ export function buildTestTx(enabledFeatures, credModes, walletRewardAddrHex, wal
   if (enabledFeatures.has('authCommittee')) {
     const coldCred = wasm.Credential.from_keyhash(wasm.Ed25519KeyHash.from_hex(COMMITTEE_COLD_HASH))
     const hotCred = wasm.Credential.from_keyhash(wasm.Ed25519KeyHash.from_hex(COMMITTEE_HOT_HASH))
-    certBuilder.add(
-      wasm.Certificate.new_committee_hot_auth(wasm.CommitteeHotAuth.new(coldCred, hotCred)),
-    )
+    certBuilder.add(wasm.Certificate.new_committee_hot_auth(wasm.CommitteeHotAuth.new(coldCred, hotCred)))
     hasCerts = true
   }
   if (enabledFeatures.has('resignCommittee')) {
     const coldCred = wasm.Credential.from_keyhash(wasm.Ed25519KeyHash.from_hex(COMMITTEE_COLD_HASH))
-    certBuilder.add(
-      wasm.Certificate.new_committee_cold_resign(wasm.CommitteeColdResign.new(coldCred)),
-    )
+    certBuilder.add(wasm.Certificate.new_committee_cold_resign(wasm.CommitteeColdResign.new(coldCred)))
     hasCerts = true
   }
 
@@ -400,10 +377,7 @@ export function buildTestTx(enabledFeatures, credModes, walletRewardAddrHex, wal
     const votingBuilder = wasm.VotingBuilder.new()
     const drepCred = wasm.Credential.from_keyhash(wasm.Ed25519KeyHash.from_hex(DREP_KEY_HASH))
     const voter = wasm.Voter.new_drep_credential(drepCred)
-    const govActionId = wasm.GovernanceActionId.new(
-      wasm.TransactionHash.from_hex(FAKE_TX_HASH),
-      0,
-    )
+    const govActionId = wasm.GovernanceActionId.new(wasm.TransactionHash.from_hex(FAKE_TX_HASH), 0)
     const votingProcedure = wasm.VotingProcedure.new(wasm.VoteKind.Yes)
     votingBuilder.add(voter, govActionId, votingProcedure)
     txBuilder.set_voting_builder(votingBuilder)
@@ -425,9 +399,7 @@ export function buildTestTx(enabledFeatures, credModes, walletRewardAddrHex, wal
   // ---- Mint / Burn ----
   if (enabledFeatures.has('mint') || enabledFeatures.has('burn')) {
     const mintBuilder = wasm.MintBuilder.new()
-    const mintWitness = wasm.MintWitness.new_native_script(
-      wasm.NativeScriptSource.new(mintNativeScript),
-    )
+    const mintWitness = wasm.MintWitness.new_native_script(wasm.NativeScriptSource.new(mintNativeScript))
     if (enabledFeatures.has('mint')) {
       mintBuilder.add_asset(
         mintWitness,
@@ -480,23 +452,14 @@ export function buildTestTx(enabledFeatures, credModes, walletRewardAddrHex, wal
 
   // ---- Collateral ----
   if (enabledFeatures.has('collateralInputs')) {
-    const collateralInput = wasm.TransactionInput.new(
-      wasm.TransactionHash.from_hex(COLLATERAL_TX_HASH),
-      0,
-    )
+    const collateralInput = wasm.TransactionInput.new(wasm.TransactionHash.from_hex(COLLATERAL_TX_HASH), 0)
     const collateralAmount = wasm.Value.new(strToBigNum('20000000'))
     const txInputsBuilder = wasm.TxInputsBuilder.new()
-    txInputsBuilder.add_key_input(
-      wasm.Ed25519KeyHash.from_hex(PAYMENT_KEY_HASH),
-      collateralInput,
-      collateralAmount,
-    )
+    txInputsBuilder.add_key_input(wasm.Ed25519KeyHash.from_hex(PAYMENT_KEY_HASH), collateralInput, collateralAmount)
     txBuilder.set_collateral(txInputsBuilder)
   }
   if (enabledFeatures.has('collateralReturn')) {
-    txBuilder.set_collateral_return(
-      wasm.TransactionOutput.new(changeAddr, wasm.Value.new(strToBigNum('10000000'))),
-    )
+    txBuilder.set_collateral_return(wasm.TransactionOutput.new(changeAddr, wasm.Value.new(strToBigNum('10000000'))))
   }
   if (enabledFeatures.has('totalCollateral')) {
     txBuilder.set_total_collateral(strToBigNum('10000000'))
@@ -504,9 +467,7 @@ export function buildTestTx(enabledFeatures, credModes, walletRewardAddrHex, wal
 
   // ---- Reference Inputs ----
   if (enabledFeatures.has('refInputs')) {
-    txBuilder.add_reference_input(
-      wasm.TransactionInput.new(wasm.TransactionHash.from_hex(REF_INPUT_TX_HASH), 0),
-    )
+    txBuilder.add_reference_input(wasm.TransactionInput.new(wasm.TransactionHash.from_hex(REF_INPUT_TX_HASH), 0))
   }
 
   // ---- Script Data Hash ----

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -8,6 +8,29 @@ export function hexToBytes(hex) {
   return Buffer.from(hex, 'hex')
 }
 
+// Splits a string into an array of chunks each <= 64 bytes when UTF-8 encoded.
+// Cardano metadatum text strings (CIP-20 messages, CIP-25 NFT fields) are capped
+// at 64 BYTES (not chars). We accumulate whole code points (iterating a string
+// yields code points, not UTF-16 units) so we never split a multibyte character.
+export function chunkMessageTo64Bytes(message) {
+  const chunks = []
+  let current = ''
+  let currentBytes = 0
+  for (const ch of message) {
+    const chBytes = Buffer.byteLength(ch, 'utf8')
+    if (currentBytes + chBytes > 64) {
+      if (current) chunks.push(current)
+      current = ch
+      currentBytes = chBytes
+    } else {
+      current += ch
+      currentBytes += chBytes
+    }
+  }
+  if (current) chunks.push(current)
+  return chunks
+}
+
 export function wasmMultiassetToJSONs(wasmMultiasset) {
   let assetValue = []
   const wasmScriptHashes = wasmMultiasset?.keys()

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,4 +1,5 @@
-import {bytesToHex, hexToBytes} from './utils'
+import {Buffer} from 'buffer'
+import {bytesToHex, hexToBytes, chunkMessageTo64Bytes} from './utils'
 
 describe('bytesToHex / hexToBytes', () => {
   it('encodes bytes to a hex string', () => {
@@ -12,5 +13,31 @@ describe('bytesToHex / hexToBytes', () => {
   it('round-trips arbitrary data', () => {
     const original = [222, 173, 190, 239]
     expect(Array.from(hexToBytes(bytesToHex(original)))).toEqual(original)
+  })
+})
+
+describe('chunkMessageTo64Bytes', () => {
+  it('returns a single chunk for strings <= 64 bytes', () => {
+    expect(chunkMessageTo64Bytes('hello')).toEqual(['hello'])
+  })
+
+  it('returns an empty array for an empty string', () => {
+    expect(chunkMessageTo64Bytes('')).toEqual([])
+  })
+
+  it('splits on 64-byte boundaries for ASCII', () => {
+    const input = 'a'.repeat(130)
+    const chunks = chunkMessageTo64Bytes(input)
+    expect(chunks.map((c) => c.length)).toEqual([64, 64, 2])
+    expect(chunks.join('')).toBe(input)
+  })
+
+  it('chunks by bytes, never splitting a multibyte character', () => {
+    // '€' is 3 UTF-8 bytes; 30 of them = 90 bytes -> must span 2 chunks,
+    // and each chunk must stay <= 64 bytes without a broken character.
+    const input = '€'.repeat(30)
+    const chunks = chunkMessageTo64Bytes(input)
+    chunks.forEach((c) => expect(Buffer.byteLength(c, 'utf8')).toBeLessThanOrEqual(64))
+    expect(chunks.join('')).toBe(input)
   })
 })

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,0 +1,16 @@
+import {bytesToHex, hexToBytes} from './utils'
+
+describe('bytesToHex / hexToBytes', () => {
+  it('encodes bytes to a hex string', () => {
+    expect(bytesToHex([0, 1, 15, 16, 255])).toBe('00010f10ff')
+  })
+
+  it('decodes a hex string back to bytes', () => {
+    expect(Array.from(hexToBytes('00010f10ff'))).toEqual([0, 1, 15, 16, 255])
+  })
+
+  it('round-trips arbitrary data', () => {
+    const original = [222, 173, 190, 239]
+    expect(Array.from(hexToBytes(bytesToHex(original)))).toEqual(original)
+  })
+})


### PR DESCRIPTION
## Summary

Correctness fixes, DRY refactors, a debug-gated logger, tests + CI, error toasts, tooling/docs, and a light shared chain abstraction — plus two UI/util fixes found while testing. Behavior-preserving throughout (or better); reviewed and verified.

## What's included

**Correctness**
- `ApiCard` height via a static Tailwind class map (dynamic `h-${n}` was being purged).
- `useContext` guards `=== undefined` → `!context` (default was `null`, so they never fired).
- `connect()` param `requestId` → `requestIdentification`.
- Network toggle was unclickable on the titles — inactive Material Tailwind `TabPanel`s overlaid the page; now render only the active tab's content.

**Refactors (DRY)**
- Renamed `yoroiProvider` → `cardanoProvider` / `useYoroi` → `useCardano`.
- Memoized `cardanoProvider`; shared `useConnectionState` state machine adopted by all providers; documented `ChainProvider` contract.
- `runApiCall` helper (22 cards), `useResponseState` (7 subtabs), `buildCert` (8 gov panels), `hexArrayToBech32Addresses`/`hexArrayToUtxos`, `parseCredential`, `ChainStatusMessage`, `AccessButtonShell`, `InputWithLabel` extended (routed ~22 input blocks), shared `chunkMessageTo64Bytes`.

**Logging**
- Debug-gated `logger` replacing 159 `console.*` calls; runtime toggle via `window.dappLogs` (persisted in localStorage) — flip logs on a deployed build without rebuilding.

**Tests & CI**
- Jest + RTL suites (39 tests): utils, logger, toast, connection-state, runApiCall, ApiCard.
- `test.yml` runs format/lint/tests on push+PR; `build.yml` writes a production `.env` (`REACT_APP_DEBUG=false`).

**Error UX**
- Toast system for wallet-connect failures (previously console-only).

**Tooling / docs**
- `prettier` dep + `lint`/`format` scripts; expanded README; `.env.example`.

## Notes
- Step "Bitcoin implementation" was intentionally deferred (BTC support undecided).
- Verified: `npm run lint`, `npm run format:check`, `npm run test:ci` (39 pass), `CI=true` build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide touch across wallet API cards and providers with behavior intended to stay the same; tab and Tailwind fixes are localized UI risks, while refactors could subtly change error/waiting handling if runApiCall options differ per card.
> 
> **Overview**
> This release (**2.4.0**) is a broad maintainability and correctness pass: shared helpers and hooks, a debug-gated logger, visible error toasts, automated checks in CI, and a couple of UI fixes—without changing the dApp’s core wallet flows.
> 
> **Correctness & UI:** `ApiCard` now maps heights to static Tailwind classes so production builds don’t strip dynamic `h-${n}` classes. **`tabsComponent`** only mounts the active tab (fixes Material Tailwind panels overlaying the network toggle). Provider hooks use **`!context`** for missing-provider errors. Cardano **`connect`** uses **`requestIdentification`** instead of **`requestId`**.
> 
> **Architecture:** **`yoroiProvider`** is renamed to **`cardanoProvider`** / **`useCardano`**. Shared **`useConnectionState`**, **`useResponseState`**, **`runApiCall`** (many API cards), **`buildCert`** (gov panels), **`parseCredential`**, **`AccessButtonShell`**, **`ChainStatusMessage`**, and extended **`InputWithLabel`** cut duplicated code. **`console.*`** is replaced by **`logger`** with **`REACT_APP_DEBUG`** and runtime **`dappLogs`** toggles. Wallet connect failures surface via **`ToastProvider`**.
> 
> **Tooling:** New **`test.yml`** (format, lint, **`test:ci`**); **`build.yml`** writes production **`.env`**; Prettier/lint scripts, **`.env.example`**, and README updates. Adds unit tests (e.g. ApiCard, hooks, logger).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56a23dc7d94eaabe657148228cc2052291035d23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->